### PR TITLE
Allow customer ids between 0 and 11 chars in QrPaymentReferenceGenerator

### DIFF
--- a/src/Reference/QrPaymentReferenceGenerator.php
+++ b/src/Reference/QrPaymentReferenceGenerator.php
@@ -19,10 +19,13 @@ class QrPaymentReferenceGenerator implements SelfValidatableInterface
     /** @var string */
     private $referenceNumber;
 
-    public static function generate(string $customerIdentificationNumber, string $referenceNumber)
+    public static function generate(?string $customerIdentificationNumber, string $referenceNumber)
     {
         $qrPaymentReferenceGenerator = new self();
-        $qrPaymentReferenceGenerator->customerIdentificationNumber = $qrPaymentReferenceGenerator->removeWhitespace($customerIdentificationNumber);
+
+        if (null !== $customerIdentificationNumber) {
+            $qrPaymentReferenceGenerator->customerIdentificationNumber = $qrPaymentReferenceGenerator->removeWhitespace($customerIdentificationNumber);
+        }
         $qrPaymentReferenceGenerator->referenceNumber = $qrPaymentReferenceGenerator->removeWhitespace($referenceNumber);
 
         return $qrPaymentReferenceGenerator->doGenerate();
@@ -62,10 +65,8 @@ class QrPaymentReferenceGenerator implements SelfValidatableInterface
                 'match' => true
             ]),
             new Assert\Length([
-                'max' => 11,
-                'min' => 4
+                'max' => 11
             ]),
-            new Assert\NotBlank()
         ]);
 
         $metadata->addPropertyConstraints('referenceNumber', [

--- a/tests/Reference/QrPaymentReferenceGeneratorTest.php
+++ b/tests/Reference/QrPaymentReferenceGeneratorTest.php
@@ -40,6 +40,9 @@ class QrPaymentReferenceGeneratorTest extends TestCase
             ['040329', '340 ', '040329000000000000000003406'], // https://www.lukb.ch/documents/10620/13334/LUKB-BESR-Handbuch.pdf
             ['247656', '3073000002311006 ', '247656000030730000023110061'], // https://hilfe.flexbuero.ch/article/1181/
             ['123456', '11223344', '123456000000000000112233440'],
+            ['1234567890', '11223344', '123456789000000000112233444'],
+            ['1234', '11223344', '123400000000000000112233449'],
+            ['000000', '11223344', '000000000000000000112233442'],
 
             // Handle it as numerics as well
             [310014, 18310019779911119, '310014000183100197799111196'],
@@ -50,12 +53,33 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     }
 
     /**
+     * @dataProvider invalidQrPaymentReferenceProvider
+     * @expectedException Sprain\SwissQrBill\Validator\Exception\InvalidQrPaymentReferenceException
+     */
+    public function testInvalidQrPaymentReference($customerIdentification, $referenceNumber)
+    {
+        QrPaymentReferenceGenerator::generate(
+            $customerIdentification,
+            $referenceNumber
+        );
+    }
+
+    public function invalidQrPaymentReferenceProvider()
+    {
+        return [
+            ['1234', '12345678901234567890123'], // too long in total
+            ['123456', '123456789012345678901'], // too long in total
+            ['12345678901', '1234567890123456'], // too long in total
+        ];
+    }
+
+    /**
      * @dataProvider invalidCustomerIdentificationNumberProvider
      * @expectedException Sprain\SwissQrBill\Validator\Exception\InvalidQrPaymentReferenceException
      */
     public function testInvalidCustomerIdentificationNumber($value)
     {
-        $qrReference = QrPaymentReferenceGenerator::generate(
+        QrPaymentReferenceGenerator::generate(
             $value,
             '18310019779911119'
         );
@@ -64,7 +88,8 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     public function invalidCustomerIdentificationNumberProvider()
     {
         return [
-            ['1234567'], // too long
+            ['123'], // too short
+            ['123456789012'], // too long
             ['12345A'],  // non-digits
             ['1234.5'],  // non-digits
             ['']
@@ -77,7 +102,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
      */
     public function testInvalidReferenceNumber($value)
     {
-        $qrReference = QrPaymentReferenceGenerator::generate(
+        QrPaymentReferenceGenerator::generate(
             '123456',
             $value
         );
@@ -86,7 +111,6 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     public function invalidReferenceNumberProvider()
     {
         return [
-            ['123456789012345678901'], // too long
             ['1234567890123456789A'],  // non-digits
             ['123456789012345678.0'],  // non-digits
             ['']

--- a/tests/Reference/QrPaymentReferenceGeneratorTest.php
+++ b/tests/Reference/QrPaymentReferenceGeneratorTest.php
@@ -43,6 +43,8 @@ class QrPaymentReferenceGeneratorTest extends TestCase
             ['1234567890', '11223344', '123456789000000000112233444'],
             ['1234', '11223344', '123400000000000000112233449'],
             ['000000', '11223344', '000000000000000000112233442'],
+            ['', '11223344', '000000000000000000112233442'],
+            [null, '11223344', '000000000000000000112233442'],
 
             // Handle it as numerics as well
             [310014, 18310019779911119, '310014000183100197799111196'],
@@ -70,6 +72,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
             ['1234', '12345678901234567890123'], // too long in total
             ['123456', '123456789012345678901'], // too long in total
             ['12345678901', '1234567890123456'], // too long in total
+            [null, '123456789012345678901234567'], // too long in total
         ];
     }
 
@@ -88,11 +91,9 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     public function invalidCustomerIdentificationNumberProvider()
     {
         return [
-            ['123'], // too short
             ['123456789012'], // too long
             ['12345A'],  // non-digits
             ['1234.5'],  // non-digits
-            ['']
         ];
     }
 


### PR DESCRIPTION
Fixes #29 

This pr allows the `customerIdentificationNumber` in a reference number to have a flexible length between 4 and 11 characters. The total of `customerIdentificationNumber + referenceNumber` may still not exceed 26 characters.