### PR TITLE
Update kmukku/php-iso11649 to require v1.5 at least

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "symfony/validator": "^3.4|^4.2|^5.0",
         "symfony/intl": "^3.4|^4.2|^5.0",
         "khanamiryan/qrcode-detector-decoder": "^1.0.3",
-        "kmukku/php-iso11649": "^1.4",
+        "kmukku/php-iso11649": "^1.5",
         "endroid/qr-code": "^3.5.3"
     },
     "require-dev": {

--- a/src/Constraint/ValidCreditorReferenceValidator.php
+++ b/src/Constraint/ValidCreditorReferenceValidator.php
@@ -14,16 +14,6 @@ class ValidCreditorReferenceValidator extends ConstraintValidator
             return;
         }
 
-        // Catch any invalid characters which are not allowed in ISO11649
-        // (but may not be caught by the underlying library)
-        if (!preg_match('/^[\w ]*$/', $value)) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ string }}', $value)
-                ->addViolation();
-
-            return;
-        }
-
         $referenceGenerator = new phpIso11649();
 
         if (false === $referenceGenerator->validateRfReference($value)) {


### PR DESCRIPTION
Catching invalid characters is built right into this library.
See https://github.com/kmukku/php-iso11649/issues/1