### PR TITLE
Improve HtmlOutput css styles

### DIFF
--- a/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
+++ b/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
@@ -10,9 +10,12 @@ class PaymentPartTemplate
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/src/PaymentPart/Output/HtmlOutput/Template/PrintableStylesTemplate.php
+++ b/src/PaymentPart/Output/HtmlOutput/Template/PrintableStylesTemplate.php
@@ -6,6 +6,10 @@ class PrintableStylesTemplate
 {
     public const TEMPLATE = <<<EOT
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-additional-information.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-additional-information.print.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-additional-information.print.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.print.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.print.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-full-set.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-full-set.print.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-full-set.print.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.print.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.print.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.print.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.print.html
@@ -159,6 +159,10 @@
 }
 
 #qr-bill-separate-info {
+    border-bottom: 0;
+}
+
+#qr-bill-separate-info-text {
     display: none;
 }
 

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.print.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.print.html
@@ -3,9 +3,12 @@
 	box-sizing: border-box;
 	width: 210mm;
 	height: 105mm;
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 	border-collapse: collapse;
 	color: #000;
+}
+
+#qr-bill * {
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
 }
 
 #qr-bill img.qr-bill-placeholder {


### PR DESCRIPTION
* Improve css in HtmlOutput to define font for all child elements. This may be relevant if other css on the same page is present which may have a higher specificity otherwise.

* Adjust output of HtmlOutput in printable view to keep the same positioning of the payment part without the need for external adjustments in the integration.