### PR TITLE
TcPdfOutput : Fix cell height ratio

### DIFF
--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -72,6 +72,8 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
 
     public function getPaymentPart(): void
     {
+        $retainCellHeightRatio = $this->tcPdf->getCellHeightRatio();
+
         $this->tcPdf->SetAutoPageBreak(false);
 
         $this->addSeparatorContentIfNotPrintable();
@@ -85,6 +87,8 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
         $this->addCurrencyContent();
         $this->addAmountContent();
         $this->addFurtherInformationContent();
+        
+        $this->tcPdf->setCellHeightRatio($retainCellHeightRatio);
     }
 
     private function addSwissQrCodeImage(): void


### PR DESCRIPTION
Because the payment slip generation adjusts the cell height ratio, the document ratio used by the user must be retained, then reset after the generation.