### PR TITLE
Added generator for ISO11649 Creditor Reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "endroid/qr-code": "^3.9.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4|^7.0",
+        "phpunit/phpunit": "^7.5",
         "symfony/css-selector": "^4.2",
         "phpstan/phpstan": "^0.12.23",
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc5552868addb5b968fbb0e4339b15ba",
+    "content-hash": "3d4057f2f2fb1dd3fa23b028de049a39",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -159,6 +159,12 @@
                 "php",
                 "qr",
                 "qrcode"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/endroid",
+                    "type": "github"
+                }
             ],
             "time": "2020-07-10T10:16:06+00:00"
         },
@@ -347,6 +353,20 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-27T08:34:37+00:00"
         },
         {
@@ -405,6 +425,20 @@
                 "string",
                 "symfony",
                 "words"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-20T17:43:50+00:00"
         },
@@ -482,6 +516,20 @@
                 "l10n",
                 "localization"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T20:35:19+00:00"
         },
         {
@@ -537,6 +585,20 @@
                 "config",
                 "configuration",
                 "options"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-23T13:08:13+00:00"
         },
@@ -599,6 +661,20 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-06T08:46:27+00:00"
         },
@@ -664,6 +740,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -725,6 +815,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-06T08:46:27+00:00"
         },
@@ -793,6 +897,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-14T14:40:37+00:00"
         },
         {
@@ -855,6 +973,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-06T08:46:27+00:00"
         },
@@ -921,6 +1053,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-06T08:46:27+00:00"
         },
@@ -990,6 +1136,20 @@
                 "property",
                 "property path",
                 "reflection"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-04T09:56:18+00:00"
         },
@@ -1068,6 +1228,20 @@
                 "type",
                 "validator"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-15T11:50:15+00:00"
         },
         {
@@ -1139,6 +1313,20 @@
                 "utf-8",
                 "utf8"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-11T12:16:36+00:00"
         },
         {
@@ -1195,6 +1383,20 @@
                 "interfaces",
                 "interoperability",
                 "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-20T17:43:50+00:00"
         },
@@ -1291,6 +1493,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-02T08:42:14+00:00"
         }
     ],
@@ -1397,6 +1613,20 @@
             "keywords": [
                 "Xdebug",
                 "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-04T11:16:35+00:00"
         },
@@ -1523,6 +1753,20 @@
                 "constructor",
                 "instantiate"
             ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-29T17:27:14+00:00"
         },
         {
@@ -1584,6 +1828,20 @@
                 "lexer",
                 "parser",
                 "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-25T17:44:05+00:00"
         },
@@ -1718,6 +1976,12 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
             "time": "2020-06-27T23:57:46+00:00"
         },
         {
@@ -1765,6 +2029,12 @@
                 "duplicate",
                 "object",
                 "object graph"
+            ],
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-29T13:22:24+00:00"
         },
@@ -2216,6 +2486,20 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-07-01T11:57:52+00:00"
         },
         {
@@ -3339,6 +3623,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-15T12:59:21+00:00"
         },
         {
@@ -3392,6 +3690,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -3464,6 +3776,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -3522,6 +3848,20 @@
                 "interoperability",
                 "standards"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -3572,6 +3912,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T20:35:19+00:00"
         },
         {
@@ -3621,6 +3975,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -3684,6 +4052,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -3738,6 +4120,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-12T16:47:27+00:00"
         },
@@ -3801,6 +4197,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -3851,6 +4261,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-30T20:35:19+00:00"
         },
         {
@@ -3909,6 +4333,20 @@
                 "interoperability",
                 "standards"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -3959,6 +4397,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-20T17:43:50+00:00"
         },
         {
@@ -4034,6 +4486,20 @@
             "keywords": [
                 "debug",
                 "dump"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-30T20:35:19+00:00"
         },
@@ -4197,5 +4663,6 @@
     "platform": {
         "php": "^7.2"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/example/example_scor.php
+++ b/example/example_scor.php
@@ -52,7 +52,7 @@ $qrBill->setPaymentAmountInformation(
 $qrBill->setPaymentReference(
     QrBill\DataGroup\Element\PaymentReference::create(
         QrBill\DataGroup\Element\PaymentReference::TYPE_SCOR,
-        'RF18539007547034'
+        QrBill\Reference\RfCreditorReferenceGenerator::generate('I20200631')
     ));
 
 // Optionally, add some human-readable information about what the bill is for.

--- a/src/Reference/QrPaymentReferenceGenerator.php
+++ b/src/Reference/QrPaymentReferenceGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Sprain\SwissQrBill\Reference;
 
+use Sprain\SwissQrBill\String\StringModifier;
 use Sprain\SwissQrBill\Validator\Exception\InvalidQrPaymentReferenceException;
 use Sprain\SwissQrBill\Validator\SelfValidatableInterface;
 use Sprain\SwissQrBill\Validator\SelfValidatableTrait;
@@ -24,9 +25,9 @@ class QrPaymentReferenceGenerator implements SelfValidatableInterface
         $qrPaymentReferenceGenerator = new self();
 
         if (null !== $customerIdentificationNumber) {
-            $qrPaymentReferenceGenerator->customerIdentificationNumber = $qrPaymentReferenceGenerator->removeWhitespace($customerIdentificationNumber);
+            $qrPaymentReferenceGenerator->customerIdentificationNumber = StringModifier::stripWhitespace($customerIdentificationNumber);
         }
-        $qrPaymentReferenceGenerator->referenceNumber = $qrPaymentReferenceGenerator->removeWhitespace($referenceNumber);
+        $qrPaymentReferenceGenerator->referenceNumber = StringModifier::stripWhitespace($referenceNumber);
 
         return $qrPaymentReferenceGenerator->doGenerate();
     }
@@ -87,11 +88,6 @@ class QrPaymentReferenceGenerator implements SelfValidatableInterface
             $context->buildViolation('The length of customer identification number + reference number may not exceed 26 characters in total.')
                 ->addViolation();
         }
-    }
-
-    private function removeWhitespace(string $string): string
-    {
-        return preg_replace('/\s+/', '', $string);
     }
 
     private function modulo10(string $number): int

--- a/src/Reference/RfCreditorReferenceGenerator.php
+++ b/src/Reference/RfCreditorReferenceGenerator.php
@@ -3,6 +3,7 @@
 namespace Sprain\SwissQrBill\Reference;
 
 use kmukku\phpIso11649\phpIso11649;
+use Sprain\SwissQrBill\String\StringModifier;
 use Sprain\SwissQrBill\Validator\Exception\InvalidCreditorReferenceException;
 use Sprain\SwissQrBill\Validator\SelfValidatableInterface;
 use Sprain\SwissQrBill\Validator\SelfValidatableTrait;
@@ -39,7 +40,7 @@ class RfCreditorReferenceGenerator implements SelfValidatableInterface
      */
     public function __construct(string $reference)
     {
-        $this->reference = str_replace(' ', '', $reference);
+        $this->reference = StringModifier::stripWhitespace($reference);
     }
 
     /**

--- a/src/Reference/RfCreditorReferenceGenerator.php
+++ b/src/Reference/RfCreditorReferenceGenerator.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Sprain\SwissQrBill\Reference;
+
+use kmukku\phpIso11649\phpIso11649;
+use Sprain\SwissQrBill\Validator\Exception\InvalidCreditorReferenceException;
+use Sprain\SwissQrBill\Validator\SelfValidatableInterface;
+use Sprain\SwissQrBill\Validator\SelfValidatableTrait;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+class RfCreditorReferenceGenerator implements SelfValidatableInterface
+{
+    use SelfValidatableTrait;
+
+    /**
+     * @var string
+     */
+    protected $reference;
+
+    /**
+     * Transform a string to a valid CreditorReference.
+     *
+     * @param string $reference
+     * @return string
+     * @throws \Exception
+     */
+    public static function generate(string $reference) : string
+    {
+        $generator = new self($reference);
+
+        return $generator->doGenerate();
+    }
+
+    /**
+     * RfCreditorReferenceGenerator constructor.
+     *
+     * @param $reference
+     */
+    public function __construct(string $reference)
+    {
+        $this->reference = str_replace(' ', '', $reference);
+    }
+
+    /**
+     * Run the generator.
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public function doGenerate() : string
+    {
+        if (!$this->isValid()) {
+            throw new InvalidCreditorReferenceException(
+                'The provided data is not valid to generate a creditor reference. Use getViolations() to find details.'
+            );
+        }
+
+        $generator = new phpIso11649();
+
+        return $generator->generateRfReference($this->reference, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addPropertyConstraints('reference', [
+            new Assert\Regex([
+                'pattern' => '~^[a-zA-Z0-9]*$~',
+                'match' => true
+            ]),
+            new Assert\Length([
+                'min' => 1,
+                'max' => 21 // 25 - 'RF' - CheckSum
+            ])
+        ]);
+    }
+}

--- a/src/Reference/RfCreditorReferenceGenerator.php
+++ b/src/Reference/RfCreditorReferenceGenerator.php
@@ -36,7 +36,7 @@ class RfCreditorReferenceGenerator implements SelfValidatableInterface
     /**
      * RfCreditorReferenceGenerator constructor.
      *
-     * @param $reference
+     * @param string $reference
      */
     public function __construct(string $reference)
     {

--- a/src/Reference/RfCreditorReferenceGenerator.php
+++ b/src/Reference/RfCreditorReferenceGenerator.php
@@ -75,7 +75,8 @@ class RfCreditorReferenceGenerator implements SelfValidatableInterface
             new Assert\Length([
                 'min' => 1,
                 'max' => 21 // 25 - 'RF' - CheckSum
-            ])
+            ]),
+            new Assert\NotBlank()
         ]);
     }
 }

--- a/src/String/StringModifier.php
+++ b/src/String/StringModifier.php
@@ -13,4 +13,9 @@ class StringModifier
     {
         return preg_replace('/ +/', ' ', $string);
     }
+
+    public static function stripWhitespace(?string $string): string
+    {
+        return preg_replace('/\s+/', '', $string);
+    }
 }

--- a/src/Validator/Exception/InvalidCreditorReferenceException.php
+++ b/src/Validator/Exception/InvalidCreditorReferenceException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sprain\SwissQrBill\Validator\Exception;
+
+class InvalidCreditorReferenceException extends \Exception
+{
+
+}

--- a/src/Validator/Exception/InvalidCreditorReferenceException.php
+++ b/src/Validator/Exception/InvalidCreditorReferenceException.php
@@ -4,5 +4,4 @@ namespace Sprain\SwissQrBill\Validator\Exception;
 
 class InvalidCreditorReferenceException extends \Exception
 {
-
 }

--- a/tests/Reference/RfCreditorReferenceGeneratorTest.php
+++ b/tests/Reference/RfCreditorReferenceGeneratorTest.php
@@ -53,7 +53,7 @@ class RfCreditorReferenceGeneratorTest extends TestCase
     {
         $generator = new RfCreditorReferenceGenerator($input);
 
-        $this->assertCount(1, $generator->getViolations());
+        $this->assertGreaterThan(0, $generator->getViolations()->count());
     }
 
     public function invalidReferenceProvider()

--- a/tests/Reference/RfCreditorReferenceGeneratorTest.php
+++ b/tests/Reference/RfCreditorReferenceGeneratorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Sprain\Tests\SwissQrBill\Reference;
+
+use Sprain\SwissQrBill\Reference\RfCreditorReferenceGenerator;
+use PHPUnit\Framework\TestCase;
+use Sprain\SwissQrBill\String\StringModifier;
+
+class RfCreditorReferenceGeneratorTest extends TestCase
+{
+    /**
+     * @dataProvider rfCreditorReferenceProvider
+     */
+    public function testMakesResultsViaConstructor($input)
+    {
+        $generator = new RfCreditorReferenceGenerator($input);
+
+        $output = $generator->doGenerate();
+
+        $this->assertStringContainsStringIgnoringCase(
+            StringModifier::stripWhitespace($input),
+            StringModifier::stripWhitespace($output)
+        );
+    }
+
+    /**
+     * @dataProvider rfCreditorReferenceProvider
+     */
+    public function testMakesResultsViaFacade($input)
+    {
+        $output = RfCreditorReferenceGenerator::generate($input);
+
+        $this->assertStringContainsStringIgnoringCase(
+            StringModifier::stripWhitespace($input),
+            StringModifier::stripWhitespace($output)
+        );
+    }
+
+    public function rfCreditorReferenceProvider()
+    {
+        return [
+            ['1'],
+            ['a'],
+            ['B'],
+            ['aBcD eFgH iJkL mNoP qR12 3'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidReferenceProvider
+     */
+    public function testInvalidReference($input)
+    {
+        $generator = new RfCreditorReferenceGenerator($input);
+
+        $this->assertCount(1, $generator->getViolations());
+    }
+
+    public function invalidReferenceProvider()
+    {
+        return [
+            ['aBcD eFgH iJkL mNoP qR12 34'], // to long
+            [''], // to short
+            ['123ä'], // invalid letter
+            ['123.'], // invalid symbol
+        ];
+    }
+
+}

--- a/tests/String/StringModifierTest.php
+++ b/tests/String/StringModifierTest.php
@@ -46,4 +46,26 @@ class StringModifierTest extends TestCase
             ["foo  bar  baz", "foo bar baz"],
         ];
     }
+
+    /**
+     * @dataProvider stripWhitespaceProvider
+     */
+    public function testStripWhitespace($string, $expectedResult)
+    {
+        $this->assertSame(
+            $expectedResult,
+            StringModifier::stripWhitespace($string)
+        );
+    }
+
+    public function stripWhitespaceProvider()
+    {
+        return [
+            ['1 ', '1'],
+            [' 2', '2'],
+            [' foo ', 'foo'],
+            ['   foo   ', 'foo'],
+            ['   foo   bar   ', 'foobar'],
+        ];
+    }
 }


### PR DESCRIPTION
I found this missing and had to do some investigation before i found out how to work with it.

In my opinion, it makes sense to add a generator for this, working the same way as the `QrPaymentReferenceGenerator`. I think that's what you're looking for as a developer.

Looking at the QrPaymentReferenceGenerator:
Maybe I'm not understanding it, but as I see there a Validator in place, which is used in the `doGenerate()`-method. However, `getViolations()` seems inaccessible, as the instasnce is never exposed.
Of curse it's possible to get a new instance with `new`, but then it's not possible to set the properties.

Because of this I used a different approach for the creation and the facade in RfCreditorReferenceGenerator. But I'm open for inputs.