### PR TITLE
Remove unneeded styles in HtmlOutput

### DIFF
--- a/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
+++ b/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
@@ -8,8 +8,6 @@ class PaymentPartTemplate
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-additional-information.png.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-additional-information.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-additional-information.svg.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-additional-information.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.png.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-full-set.png.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-full-set.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-full-set.svg.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-full-set.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.png.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.png.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.svg.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.png.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.png.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.png.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.png.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.png.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.png.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.png.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.png.print.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.png.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.print.html
@@ -1,8 +1,6 @@
 <style>
 #qr-bill {
 	box-sizing: border-box;
-	width: 210mm;
-	height: 105mm;
 	border-collapse: collapse;
 	color: #000;
 }


### PR DESCRIPTION
Closes #74

Removes unneeded css styles which only contain redundant information. Height and width of the payment part is defined by the inner elements already.