### PR TITLE
Use floats for offset in pdf outputs

### DIFF
--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -51,18 +51,18 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
     /** @var float */
     private $amountLS = 0;
 
-    /* @var int */
+    /* @var float */
     private $offsetX;
 
-    /* @var int */
+    /* @var float */
     private $offsetY;
 
     public function __construct(
         QrBill $qrBill,
         string $language,
         Fpdf $fpdf,
-        int $offsetX = 0,
-        int $offsetY = 0
+        float $offsetX = 0,
+        float $offsetY = 0
     ) {
         parent::__construct($qrBill, $language);
         $this->fpdf = $fpdf;

--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -347,7 +347,7 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
         $this->tcPdf->MultiCell($w, $h, $text, self::BORDER, $textAlign, false, $nextLineAlign);
     }
 
-    private function printLine(float $x1, float $y1, float $x2, float $y2) : void
+    private function printLine(int $x1, int $y1, int $x2, int $y2) : void
     {
         $this->tcPdf->Line($x1+$this->offsetX, $y1+$this->offsetY, $x2+$this->offsetX, $y2+$this->offsetY);
     }

--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -231,8 +231,8 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
     {
         if (!$this->isPrintable()) {
             $this->tcPdf->SetLineStyle(array('width' => 0.1, 'color' => array(0, 0, 0)));
-            $this->printLine(2 + $this->offsetX, 193 + $this->offsetY, 208 + $this->offsetX, 193 + $this->offsetY);
-            $this->printLine(62 + $this->offsetX, 193 + $this->offsetY, 62 + $this->offsetX, 296 + $this->offsetY);
+            $this->printLine(2, 193, 208, 193);
+            $this->printLine(62, 193, 62, 296);
             $this->tcPdf->SetFont(self::FONT, '', self::FONT_SIZE_FURTHER_INFORMATION);
             $this->SetY(188);
             $this->SetX(5);

--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -58,18 +58,18 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
     /* @var TCPDF */
     private $tcPdf;
 
-    /* @var int */
+    /* @var float */
     private $offsetX;
 
-    /* @var int */
+    /* @var float */
     private $offsetY;
 
     public function __construct(
         QrBill $qrBill,
         string $language,
         TCPDF $tcPdf,
-        int $offsetX = 0,
-        int $offsetY = 0
+        float $offsetX = 0,
+        float $offsetY = 0
     ) {
         parent::__construct($qrBill, $language);
         $this->tcPdf = $tcPdf;
@@ -347,7 +347,7 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
         $this->tcPdf->MultiCell($w, $h, $text, self::BORDER, $textAlign, false, $nextLineAlign);
     }
 
-    private function printLine(int $x1, int $y1, int $x2, int $y2) : void
+    private function printLine(float $x1, float $y1, float $x2, float $y2) : void
     {
         $this->tcPdf->Line($x1+$this->offsetX, $y1+$this->offsetY, $x2+$this->offsetX, $y2+$this->offsetY);
     }


### PR DESCRIPTION
Closes #86 

* Allows offset of positioning of the payment part in `FpdfOutput` and `TcPdfOutput` to be a `float` instead of an `int.`
* Fixes a bug with duplicated offsetting in `TcPdfOutput`