### PR TITLE
Improve type hinting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
 
 env:
@@ -14,12 +12,12 @@ jobs:
   include:
     - stage: "Integrate"
       name: "Coding standard"
-      php: 7.3
+      php: 7.4
       env:
         - PREFER_LOWEST=""
       script: vendor/bin/php-cs-fixer --no-interaction --dry-run --diff -v fix src/
     - name: "Static analysis"
-      php: 7.3
+      php: 7.4
       env:
         - PREFER_LOWEST=""
       script: vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.4",
         "symfony/validator": "^3.4.31|^4.2|^5.0",
         "symfony/intl": "^3.4|^4.2|^5.0",
         "khanamiryan/qrcode-detector-decoder": "^1.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c4c66e8a771f371ca1568e3adc646f4",
+    "content-hash": "d5b81296edead492cd90b312e8dab248",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "add6d9ff97336b62f95a3b94f75cea4e085465b2"
+                "reference": "3e9d791b67d0a2912922b7b7c7312f4b37af41e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/add6d9ff97336b62f95a3b94f75cea4e085465b2",
-                "reference": "add6d9ff97336b62f95a3b94f75cea4e085465b2",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/3e9d791b67d0a2912922b7b7c7312f4b37af41e4",
+                "reference": "3e9d791b67d0a2912922b7b7c7312f4b37af41e4",
                 "shasum": ""
             },
             "require": {
-                "dasprid/enum": "^1.0",
+                "dasprid/enum": "^1.0.3",
                 "ext-iconv": "*",
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "phly/keep-a-changelog": "^1.4",
@@ -53,20 +53,24 @@
             ],
             "description": "BaconQrCode is a QR code generator for PHP.",
             "homepage": "https://github.com/Bacon/BaconQrCode",
-            "time": "2020-07-30T16:40:58+00:00"
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.3"
+            },
+            "time": "2020-10-30T02:02:47+00:00"
         },
         {
             "name": "dasprid/enum",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DASPRiD/Enum.git",
-                "reference": "6ccc0d7141a7f149e3c56cb0ce5f05d9152cfd07"
+                "reference": "5abf82f213618696dda8e3bf6f64dd042d8542b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/6ccc0d7141a7f149e3c56cb0ce5f05d9152cfd07",
-                "reference": "6ccc0d7141a7f149e3c56cb0ce5f05d9152cfd07",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/5abf82f213618696dda8e3bf6f64dd042d8542b2",
+                "reference": "5abf82f213618696dda8e3bf6f64dd042d8542b2",
                 "shasum": ""
             },
             "require-dev": {
@@ -96,20 +100,24 @@
                 "enum",
                 "map"
             ],
-            "time": "2020-07-30T16:37:13+00:00"
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.3"
+            },
+            "time": "2020-10-02T16:03:48+00:00"
         },
         {
             "name": "endroid/qr-code",
-            "version": "3.9.1",
+            "version": "3.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/endroid/qr-code.git",
-                "reference": "8605e2c958ed568788da4e16bd8a9502e32f375f"
+                "reference": "58d5872ca46b99b5c2e72cd2c8dea09ce2988156"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/endroid/qr-code/zipball/8605e2c958ed568788da4e16bd8a9502e32f375f",
-                "reference": "8605e2c958ed568788da4e16bd8a9502e32f375f",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/58d5872ca46b99b5c2e72cd2c8dea09ce2988156",
+                "reference": "58d5872ca46b99b5c2e72cd2c8dea09ce2988156",
                 "shasum": ""
             },
             "require": {
@@ -161,7 +169,17 @@
                 "qr",
                 "qrcode"
             ],
-            "time": "2020-07-10T10:16:06+00:00"
+            "support": {
+                "issues": "https://github.com/endroid/qr-code/issues",
+                "source": "https://github.com/endroid/qr-code/tree/3.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/endroid",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-07T09:42:59+00:00"
         },
         {
             "name": "khanamiryan/qrcode-detector-decoder",
@@ -211,6 +229,10 @@
                 "qr",
                 "zxing"
             ],
+            "support": {
+                "issues": "https://github.com/khanamiryan/php-qrcode-detector-decoder/issues",
+                "source": "https://github.com/khanamiryan/php-qrcode-detector-decoder/tree/1.0.3"
+            },
             "time": "2020-04-19T16:18:51+00:00"
         },
         {
@@ -256,20 +278,24 @@
                 "RF creditor reference",
                 "finance"
             ],
+            "support": {
+                "issues": "https://github.com/kmukku/php-iso11649/issues",
+                "source": "https://github.com/kmukku/php-iso11649/tree/master"
+            },
             "time": "2020-04-21T13:01:17+00:00"
         },
         {
             "name": "myclabs/php-enum",
-            "version": "1.7.6",
+            "version": "1.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/php-enum.git",
-                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c"
+                "reference": "d178027d1e679832db9f38248fcc7200647dc2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
-                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/d178027d1e679832db9f38248fcc7200647dc2b7",
+                "reference": "d178027d1e679832db9f38248fcc7200647dc2b7",
                 "shasum": ""
             },
             "require": {
@@ -302,20 +328,34 @@
             "keywords": [
                 "enum"
             ],
-            "time": "2020-02-14T08:15:52+00:00"
+            "support": {
+                "issues": "https://github.com/myclabs/php-enum/issues",
+                "source": "https://github.com/myclabs/php-enum/tree/1.7.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-14T18:14:52+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14"
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5e20b83385a77593259c9f8beb2c43cd03b2ac14",
-                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
                 "shasum": ""
             },
             "require": {
@@ -324,7 +364,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -352,20 +392,37 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "time": "2020-06-06T08:49:21+00:00"
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/intl",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "b6886c43cc1ae3367c569c5a8d4182555dd694fb"
+                "reference": "e353c6c37afa1ff90739b3941f60ff9fa650eec3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/b6886c43cc1ae3367c569c5a8d4182555dd694fb",
-                "reference": "b6886c43cc1ae3367c569c5a8d4182555dd694fb",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/e353c6c37afa1ff90739b3941f60ff9fa650eec3",
+                "reference": "e353c6c37afa1ff90739b3941f60ff9fa650eec3",
                 "shasum": ""
             },
             "require": {
@@ -380,11 +437,6 @@
                 "ext-intl": "to use the component with locales other than \"en\""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Intl\\": ""
@@ -428,20 +480,37 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2020-08-17T07:42:30+00:00"
+            "support": {
+                "source": "https://github.com/symfony/intl/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "9ff59517938f88d90b6e65311fef08faa640f681"
+                "reference": "c6a02905e4ffc7a1498e8ee019db2b477cd1cc02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/9ff59517938f88d90b6e65311fef08faa640f681",
-                "reference": "9ff59517938f88d90b6e65311fef08faa640f681",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/c6a02905e4ffc7a1498e8ee019db2b477cd1cc02",
+                "reference": "c6a02905e4ffc7a1498e8ee019db2b477cd1cc02",
                 "shasum": ""
             },
             "require": {
@@ -450,11 +519,6 @@
                 "symfony/polyfill-php80": "^1.15"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\OptionsResolver\\": ""
@@ -484,24 +548,41 @@
                 "configuration",
                 "options"
             ],
-            "time": "2020-07-12T12:58:00+00:00"
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -509,7 +590,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -546,24 +627,41 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5"
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b740103edbdcc39602239ee8860f0f45a8eb9aa5",
-                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -571,7 +669,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -610,24 +708,41 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "4e45a6e39041a9cc78835b11abc47874ae302a55"
+                "reference": "c44d5bf6a75eed79555c6bf37505c6d39559353e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/4e45a6e39041a9cc78835b11abc47874ae302a55",
-                "reference": "4e45a6e39041a9cc78835b11abc47874ae302a55",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/c44d5bf6a75eed79555c6bf37505c6d39559353e",
+                "reference": "c44d5bf6a75eed79555c6bf37505c6d39559353e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=7.1",
                 "symfony/intl": "~2.3|~3.0|~4.0|~5.0"
             },
             "suggest": {
@@ -636,7 +751,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -672,24 +787,41 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e"
+                "reference": "727d1096295d807c309fb01a851577302394c897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
-                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/727d1096295d807c309fb01a851577302394c897",
+                "reference": "727d1096295d807c309fb01a851577302394c897",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -697,7 +829,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -739,24 +871,41 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -764,7 +913,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -802,29 +951,46 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981"
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/d87d5766cbf48d72388a9f6b85f280c8ad51f981",
-                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.8"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -868,20 +1034,37 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/property-access",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "c2a95da4d3b88523d00903a3d04636717766d674"
+                "reference": "5d77df9a88600797d02c7937c153965ba3537933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/c2a95da4d3b88523d00903a3d04636717766d674",
-                "reference": "c2a95da4d3b88523d00903a3d04636717766d674",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/5d77df9a88600797d02c7937c153965ba3537933",
+                "reference": "5d77df9a88600797d02c7937c153965ba3537933",
                 "shasum": ""
             },
             "require": {
@@ -896,11 +1079,6 @@
                 "psr/cache-implementation": "To cache access methods."
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\PropertyAccess\\": ""
@@ -936,20 +1114,37 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2020-08-30T08:29:58+00:00"
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "a10524dfdadc418c2e4b52667be7d6421b7da26f"
+                "reference": "fc15c51f829887b62a94a917ba793f51e80ea3e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/a10524dfdadc418c2e4b52667be7d6421b7da26f",
-                "reference": "a10524dfdadc418c2e4b52667be7d6421b7da26f",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/fc15c51f829887b62a94a917ba793f51e80ea3e1",
+                "reference": "fc15c51f829887b62a94a917ba793f51e80ea3e1",
                 "shasum": ""
             },
             "require": {
@@ -976,11 +1171,6 @@
                 "symfony/serializer": "To use Serializer metadata"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\PropertyInfo\\": ""
@@ -1013,20 +1203,37 @@
                 "type",
                 "validator"
             ],
-            "time": "2020-08-18T07:27:13+00:00"
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a"
+                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
-                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a97573e960303db71be0dd8fda9be3bca5e0feea",
+                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea",
                 "shasum": ""
             },
             "require": {
@@ -1044,11 +1251,6 @@
                 "symfony/var-exporter": "^4.4|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\String\\": ""
@@ -1084,20 +1286,37 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2020-08-17T07:48:54+00:00"
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.1.3",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "616a9773c853097607cf9dd6577d5b143ffdcd63"
+                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/616a9773c853097607cf9dd6577d5b143ffdcd63",
-                "reference": "616a9773c853097607cf9dd6577d5b143ffdcd63",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/e2eaa60b558f26a4b0354e1bbb25636efaaad105",
+                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105",
                 "shasum": ""
             },
             "require": {
@@ -1109,7 +1328,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1145,20 +1364,37 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-28T13:05:58+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "db6acf2a0ea02fdb89b561c7bba3db2c0eaecd9a"
+                "reference": "360acadab7edcdca9005c4ad3b535f9c20db62fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/db6acf2a0ea02fdb89b561c7bba3db2c0eaecd9a",
-                "reference": "db6acf2a0ea02fdb89b561c7bba3db2c0eaecd9a",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/360acadab7edcdca9005c4ad3b535f9c20db62fb",
+                "reference": "360acadab7edcdca9005c4ad3b535f9c20db62fb",
                 "shasum": ""
             },
             "require": {
@@ -1192,7 +1428,6 @@
                 "symfony/http-kernel": "^4.4|^5.0",
                 "symfony/intl": "^4.4|^5.0",
                 "symfony/mime": "^4.4|^5.0",
-                "symfony/phpunit-bridge": "^5.1",
                 "symfony/property-access": "^4.4|^5.0",
                 "symfony/property-info": "^4.4|^5.0",
                 "symfony/translation": "^4.4|^5.0",
@@ -1213,11 +1448,6 @@
                 "symfony/yaml": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Validator\\": ""
@@ -1242,34 +1472,52 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2020-08-31T09:01:51+00:00"
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-28T05:25:38+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "composer/semver",
-            "version": "1.5.1",
+            "version": "3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
-                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0"
+                "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5"
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -1305,20 +1553,39 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2020-01-13T12:06:48+00:00"
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:59:24+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.3",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "ebd27a9866ae8254e873866f795491f02418c5a5"
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ebd27a9866ae8254e873866f795491f02418c5a5",
-                "reference": "ebd27a9866ae8254e873866f795491f02418c5a5",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
                 "shasum": ""
             },
             "require": {
@@ -1349,24 +1616,43 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2020-08-19T10:27:58+00:00"
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:04:11+00:00"
         },
         {
             "name": "dms/phpunit-arraysubset-asserts",
-            "version": "v0.2.0",
+            "version": "v0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rdohms/phpunit-arraysubset-asserts.git",
-                "reference": "d33fd352dbe1ca1c7dfe2b9f516ab9a852e3e516"
+                "reference": "8e3673a70019a60df484e36fc3271d63cbdc40ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/d33fd352dbe1ca1c7dfe2b9f516ab9a852e3e516",
-                "reference": "d33fd352dbe1ca1c7dfe2b9f516ab9a852e3e516",
+                "url": "https://api.github.com/repos/rdohms/phpunit-arraysubset-asserts/zipball/8e3673a70019a60df484e36fc3271d63cbdc40ea",
+                "reference": "8e3673a70019a60df484e36fc3271d63cbdc40ea",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3",
+                "php": "^7.3|^8.0",
                 "phpunit/phpunit": "^9.0"
             },
             "require-dev": {
@@ -1390,20 +1676,24 @@
                 }
             ],
             "description": "This package provides ArraySubset and related asserts once deprecated in PHPUnit 8",
-            "time": "2020-02-12T15:25:06+00:00"
+            "support": {
+                "issues": "https://github.com/rdohms/phpunit-arraysubset-asserts/issues",
+                "source": "https://github.com/rdohms/phpunit-arraysubset-asserts/tree/v0.2.1"
+            },
+            "time": "2020-10-03T21:43:40+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.10.4",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f"
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bfe91e31984e2ba76df1c1339681770401ec262f",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
                 "shasum": ""
             },
             "require": {
@@ -1413,13 +1703,14 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
                 "phpstan/phpstan": "^0.12.20",
                 "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -1454,46 +1745,45 @@
                 }
             ],
             "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
             "keywords": [
                 "annotations",
                 "docblock",
                 "parser"
             ],
-            "time": "2020-08-10T19:35:50+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/1.11.1"
+            },
+            "time": "2020-10-26T10:28:16+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -1507,7 +1797,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -1516,7 +1806,25 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -1578,6 +1886,24 @@
                 "parser",
                 "php"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-25T17:44:05+00:00"
         },
         {
@@ -1620,31 +1946,35 @@
                 "pdf",
                 "wrapper"
             ],
+            "support": {
+                "issues": "https://github.com/coreydoughty/Fpdf/issues",
+                "source": "https://github.com/coreydoughty/Fpdf/tree/1.82.1"
+            },
             "time": "2020-02-15T12:05:43+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.16.4",
+            "version": "v2.16.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13"
+                "reference": "4e35806a6d7d8510d6842ae932e8832363d22c87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/1023c3458137ab052f6ff1e09621a721bfdeca13",
-                "reference": "1023c3458137ab052f6ff1e09621a721bfdeca13",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/4e35806a6d7d8510d6842ae932e8832363d22c87",
+                "reference": "4e35806a6d7d8510d6842ae932e8832363d22c87",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^1.2",
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.1",
                 "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
                 "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
                 "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
                 "symfony/finder": "^3.0 || ^4.0 || ^5.0",
@@ -1657,14 +1987,14 @@
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.2",
+                "keradus/cli-executor": "^1.4",
                 "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.1",
+                "php-coveralls/php-coveralls": "^2.4.1",
                 "php-cs-fixer/accessible-object": "^1.0",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
                 "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
-                "phpunitgoodpractices/traits": "^1.8",
+                "phpunitgoodpractices/traits": "^1.9.1",
                 "symfony/phpunit-bridge": "^5.1",
                 "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
@@ -1711,20 +2041,30 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2020-06-27T23:57:46+00:00"
+            "support": {
+                "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.16.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-27T22:44:27+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -1759,20 +2099,30 @@
                 "object",
                 "object graph"
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.9.1",
+            "version": "v4.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28"
+                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/88e519766fc58bd46b8265561fb79b54e2e00b28",
-                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
+                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
                 "shasum": ""
             },
             "require": {
@@ -1811,52 +2161,11 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-08-30T16:15:20+00:00"
-        },
-        {
-            "name": "paragonie/random_compat",
-            "version": "v9.99.99",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*",
-                "vimeo/psalm": "^1"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2018-07-02T15:55:56+00:00"
+            "time": "2020-09-26T10:30:38+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1912,6 +2221,10 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
             "time": "2020-06-27T14:33:11+00:00"
         },
         {
@@ -1959,27 +2272,31 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
             "time": "2020-06-27T14:39:04+00:00"
         },
         {
             "name": "php-cs-fixer/diff",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
-                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/dbd31aeb251639ac0b9e7e29405c1441907f5759",
+                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^5.6 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
                 "symfony/process": "^3.3"
             },
             "type": "library",
@@ -1994,12 +2311,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 },
                 {
                     "name": "SpacePossum"
@@ -2010,7 +2327,11 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2018-02-15T16:58:55+00:00"
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
+                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
+            },
+            "time": "2020-10-14T08:39:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2059,20 +2380,24 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
             "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.1",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44"
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d870572532cd70bc3fab58f2e23ad423c8404c44",
-                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
                 "shasum": ""
             },
             "require": {
@@ -2111,20 +2436,24 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-08-15T11:14:08+00:00"
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
+            "time": "2020-09-03T19:13:55+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
-                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
                 "shasum": ""
             },
             "require": {
@@ -2156,32 +2485,36 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-06-27T10:12:23+00:00"
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
+            "time": "2020-09-17T18:55:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.11.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160"
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b20034be5efcdab4fb60ca3a29cba2949aead160",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2",
-                "phpdocumentor/reflection-docblock": "^5.0",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
             },
             "type": "library",
             "extra": {
@@ -2219,20 +2552,24 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-07-08T12:44:21+00:00"
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.1"
+            },
+            "time": "2020-09-29T09:10:42+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.42",
+            "version": "0.12.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4"
+                "reference": "4382b2b2059ec7e5135d07685ec1e3e16ae32d16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
-                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4382b2b2059ec7e5135d07685ec1e3e16ae32d16",
+                "reference": "4382b2b2059ec7e5135d07685ec1e3e16ae32d16",
                 "shasum": ""
             },
             "require": {
@@ -2261,28 +2598,46 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2020-09-02T13:14:53+00:00"
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.55"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-14T10:20:35+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.1.7",
+            "version": "9.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2ef92bec3186a827faf7362ff92ae4e8ec2e49d2"
+                "reference": "6b20e2055f7c29b56cb3870b3de7cc463d7add41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2ef92bec3186a827faf7362ff92ae4e8ec2e49d2",
-                "reference": "2ef92bec3186a827faf7362ff92ae4e8ec2e49d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6b20e2055f7c29b56cb3870b3de7cc463d7add41",
+                "reference": "6b20e2055f7c29b56cb3870b3de7cc463d7add41",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.8",
-                "php": "^7.3 || ^8.0",
+                "nikic/php-parser": "^4.10.2",
+                "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
                 "sebastian/code-unit-reverse-lookup": "^2.0.2",
@@ -2302,7 +2657,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.1-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -2328,27 +2683,37 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-09-03T07:09:19+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-30T10:46:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.4",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "25fefc5b19835ca653877fe081644a3f8c1d915e"
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/25fefc5b19835ca653877fe081644a3f8c1d915e",
-                "reference": "25fefc5b19835ca653877fe081644a3f8c1d915e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -2378,28 +2743,38 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2020-07-11T05:18:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:57:25+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "7a85b66acc48cacffdf87dadd3694e7123674298"
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7a85b66acc48cacffdf87dadd3694e7123674298",
-                "reference": "7a85b66acc48cacffdf87dadd3694e7123674298",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2431,27 +2806,37 @@
             "keywords": [
                 "process"
             ],
-            "time": "2020-08-06T07:04:15+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "6ff9c8ea4d3212b88fcf74e25e516e2c51c99324"
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/6ff9c8ea4d3212b88fcf74e25e516e2c51c99324",
-                "reference": "6ff9c8ea4d3212b88fcf74e25e516e2c51c99324",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -2480,27 +2865,37 @@
             "keywords": [
                 "template"
             ],
-            "time": "2020-06-26T11:55:37+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.1",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "cc49734779cbb302bf51a44297dab8c4bbf941e7"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/cc49734779cbb302bf51a44297dab8c4bbf941e7",
-                "reference": "cc49734779cbb302bf51a44297dab8c4bbf941e7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.2"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -2529,20 +2924,30 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2020-06-26T11:58:13+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.3.8",
+            "version": "9.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c"
+                "reference": "9fa359ff5ddaa5eb2be2bedb08a6a5787a5807ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c",
-                "reference": "93d78d8e2a06393a0d0c1ead6fe9984f1af1f88c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9fa359ff5ddaa5eb2be2bedb08a6a5787a5807ab",
+                "reference": "9fa359ff5ddaa5eb2be2bedb08a6a5787a5807ab",
                 "shasum": ""
             },
             "require": {
@@ -2556,24 +2961,24 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.1",
                 "phar-io/version": "^3.0.2",
-                "php": "^7.3 || ^8.0",
-                "phpspec/prophecy": "^1.11.1",
-                "phpunit/php-code-coverage": "^9.1.5",
-                "phpunit/php-file-iterator": "^3.0.4",
-                "phpunit/php-invoker": "^3.1",
-                "phpunit/php-text-template": "^2.0.2",
-                "phpunit/php-timer": "^5.0.1",
-                "sebastian/cli-parser": "^1.0",
-                "sebastian/code-unit": "^1.0.5",
-                "sebastian/comparator": "^4.0.3",
-                "sebastian/diff": "^4.0.2",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/exporter": "^4.0.2",
-                "sebastian/global-state": "^5.0",
-                "sebastian/object-enumerator": "^4.0.2",
-                "sebastian/resource-operations": "^3.0.2",
-                "sebastian/type": "^2.2.1",
-                "sebastian/version": "^3.0.1"
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3",
+                "sebastian/version": "^3.0.2"
             },
             "require-dev": {
                 "ext-pdo": "*",
@@ -2589,7 +2994,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.3-dev"
+                    "dev-master": "9.4-dev"
                 }
             },
             "autoload": {
@@ -2618,7 +3023,21 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-08-27T06:30:58+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-10T12:53:30+00:00"
         },
         {
             "name": "psr/container",
@@ -2667,6 +3086,10 @@
                 "container-interop",
                 "psr"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -2713,6 +3136,10 @@
                 "psr",
                 "psr-14"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
@@ -2760,24 +3187,27 @@
                 "psr",
                 "psr-3"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
             "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2a4a38c56e62f7295bedb8b1b7439ad523d4ea82"
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2a4a38c56e62f7295bedb8b1b7439ad523d4ea82",
-                "reference": "2a4a38c56e62f7295bedb8b1b7439ad523d4ea82",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.3"
@@ -2806,27 +3236,37 @@
             ],
             "description": "Library for parsing CLI options",
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
-            "time": "2020-08-12T10:49:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.5",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "c1e2df332c905079980b119c4db103117e5e5c90"
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/c1e2df332c905079980b119c4db103117e5e5c90",
-                "reference": "c1e2df332c905079980b119c4db103117e5e5c90",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -2852,27 +3292,37 @@
             ],
             "description": "Collection of value objects that represent the PHP code units",
             "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "time": "2020-06-26T12:50:45+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ee51f9bb0c6d8a43337055db3120829fa14da819"
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ee51f9bb0c6d8a43337055db3120829fa14da819",
-                "reference": "ee51f9bb0c6d8a43337055db3120829fa14da819",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -2897,29 +3347,39 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2020-06-26T12:04:00+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "dcc580eadfaa4e7f9d2cf9ae1922134ea962e14f"
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dcc580eadfaa4e7f9d2cf9ae1922134ea962e14f",
-                "reference": "dcc580eadfaa4e7f9d2cf9ae1922134ea962e14f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0",
+                "php": ">=7.3",
                 "sebastian/diff": "^4.0",
                 "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -2961,28 +3421,38 @@
                 "compare",
                 "equality"
             ],
-            "time": "2020-06-26T12:05:46+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "33fcd6a26656c6546f70871244ecba4b4dced097"
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/33fcd6a26656c6546f70871244ecba4b4dced097",
-                "reference": "33fcd6a26656c6546f70871244ecba4b4dced097",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.7",
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.2"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -3008,27 +3478,37 @@
             ],
             "description": "Library for calculating the complexity of PHP code units",
             "homepage": "https://github.com/sebastianbergmann/complexity",
-            "time": "2020-07-25T14:01:34+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.2",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113"
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113",
-                "reference": "1e90b4cf905a7d06c420b1d2e9d11a4dc8a13113",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0",
+                "phpunit/phpunit": "^9.3",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
@@ -3064,27 +3544,37 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2020-06-30T04:46:02+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.2",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "0a757cab9d5b7ef49a619f1143e6c9c1bc0fe9d2"
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/0a757cab9d5b7ef49a619f1143e6c9c1bc0fe9d2",
-                "reference": "0a757cab9d5b7ef49a619f1143e6c9c1bc0fe9d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -3092,7 +3582,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -3117,29 +3607,39 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2020-06-26T12:07:24+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:52:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.2",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "571d721db4aec847a0e59690b954af33ebf9f023"
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/571d721db4aec847a0e59690b954af33ebf9f023",
-                "reference": "571d721db4aec847a0e59690b954af33ebf9f023",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0",
+                "php": ">=7.3",
                 "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.2"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -3184,24 +3684,34 @@
                 "export",
                 "exporter"
             ],
-            "time": "2020-06-26T12:08:55+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:24:23+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.0",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "22ae663c951bdc39da96603edc3239ed3a299097"
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/22ae663c951bdc39da96603edc3239ed3a299097",
-                "reference": "22ae663c951bdc39da96603edc3239ed3a299097",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0",
+                "php": ">=7.3",
                 "sebastian/object-reflector": "^2.0",
                 "sebastian/recursion-context": "^4.0"
             },
@@ -3238,28 +3748,38 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2020-08-07T04:09:03+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:55:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e02bf626f404b5daec382a7b8a6a4456e49017e5"
+                "reference": "acf76492a65401babcf5283296fa510782783a7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e02bf626f404b5daec382a7b8a6a4456e49017e5",
-                "reference": "e02bf626f404b5daec382a7b8a6a4456e49017e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/acf76492a65401babcf5283296fa510782783a7a",
+                "reference": "acf76492a65401babcf5283296fa510782783a7a",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.6",
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.2"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -3285,29 +3805,39 @@
             ],
             "description": "Library for counting the lines of code in PHP source code",
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-            "time": "2020-07-22T18:33:42+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T17:03:56+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.2",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "074fed2d0a6d08e1677dd8ce9d32aecb384917b8"
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/074fed2d0a6d08e1677dd8ce9d32aecb384917b8",
-                "reference": "074fed2d0a6d08e1677dd8ce9d32aecb384917b8",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0",
+                "php": ">=7.3",
                 "sebastian/object-reflector": "^2.0",
                 "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -3332,27 +3862,37 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2020-06-26T12:11:32+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "127a46f6b057441b201253526f81d5406d6c7840"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/127a46f6b057441b201253526f81d5406d6c7840",
-                "reference": "127a46f6b057441b201253526f81d5406d6c7840",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -3377,27 +3917,37 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2020-06-26T12:12:55+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.2",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "062231bf61d2b9448c4fa5a7643b5e1829c11d63"
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/062231bf61d2b9448c4fa5a7643b5e1829c11d63",
-                "reference": "062231bf61d2b9448c4fa5a7643b5e1829c11d63",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -3430,24 +3980,34 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2020-06-26T12:14:17+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0653718a5a629b065e91f774595267f8dc32e213"
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0653718a5a629b065e91f774595267f8dc32e213",
-                "reference": "0653718a5a629b065e91f774595267f8dc32e213",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.0"
@@ -3475,32 +4035,42 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2020-06-26T12:16:22+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "2.2.1",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a"
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/86991e2b33446cd96e648c18bcdb1e95afb2c05a",
-                "reference": "86991e2b33446cd96e648c18bcdb1e95afb2c05a",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.2"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -3521,24 +4091,34 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
-            "time": "2020-07-05T08:31:53+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:18:59+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "626586115d0ed31cb71483be55beb759b5af5a3c"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/626586115d0ed31cb71483be55beb759b5af5a3c",
-                "reference": "626586115d0ed31cb71483be55beb759b5af5a3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
@@ -3564,20 +4144,30 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2020-06-26T12:18:43+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf"
+                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/186f395b256065ba9b890c0a4e48a91d598fa2cf",
-                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
+                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
                 "shasum": ""
             },
             "require": {
@@ -3614,11 +4204,6 @@
                 "symfony/process": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -3643,31 +4228,43 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-09-02T07:07:40+00:00"
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.4.13",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "bf17dc9f6ce144e41f786c32435feea4d8e11dcc"
+                "reference": "719506cffda9dba80c75d94ac50f1a2561520e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/bf17dc9f6ce144e41f786c32435feea4d8e11dcc",
-                "reference": "bf17dc9f6ce144e41f786c32435feea4d8e11dcc",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/719506cffda9dba80c75d94ac50f1a2561520e4f",
+                "reference": "719506cffda9dba80c75d94ac50f1a2561520e4f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\CssSelector\\": ""
@@ -3696,20 +4293,37 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2020-07-05T09:39:30+00:00"
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v4.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "94871fc0a69c3c5da57764187724cdce0755899c"
+                "reference": "26f4edae48c913fc183a3da0553fe63bdfbd361a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/94871fc0a69c3c5da57764187724cdce0755899c",
-                "reference": "94871fc0a69c3c5da57764187724cdce0755899c",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/26f4edae48c913fc183a3da0553fe63bdfbd361a",
+                "reference": "26f4edae48c913fc183a3da0553fe63bdfbd361a",
                 "shasum": ""
             },
             "require": {
@@ -3729,6 +4343,7 @@
                 "psr/log": "~1.0",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
                 "symfony/expression-language": "^4.4|^5.0",
                 "symfony/http-foundation": "^4.4|^5.0",
                 "symfony/service-contracts": "^1.1|^2",
@@ -3739,11 +4354,6 @@
                 "symfony/http-kernel": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
@@ -3768,20 +4378,37 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2020-08-13T14:19:42+00:00"
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b"
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
-                "reference": "f6f613d74cfc5a623fc36294d3451eb7fa5a042b",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ba7d54483095a198fa51781bc608d17e84dffa2",
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2",
                 "shasum": ""
             },
             "require": {
@@ -3794,7 +4421,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3830,20 +4457,37 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "f7b9ed6142a34252d219801d9767dedbd711da1a"
+                "reference": "df08650ea7aee2d925380069c131a66124d79177"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f7b9ed6142a34252d219801d9767dedbd711da1a",
-                "reference": "f7b9ed6142a34252d219801d9767dedbd711da1a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/df08650ea7aee2d925380069c131a66124d79177",
+                "reference": "df08650ea7aee2d925380069c131a66124d79177",
                 "shasum": ""
             },
             "require": {
@@ -3851,11 +4495,6 @@
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
@@ -3880,31 +4519,43 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2020-08-21T17:19:47+00:00"
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d"
+                "reference": "e70eb5a69c2ff61ea135a13d2266e8914a67b3a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2b765f0cf6612b3636e738c0689b29aa63088d5d",
-                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e70eb5a69c2ff61ea135a13d2266e8914a67b3a0",
+                "reference": "e70eb5a69c2ff61ea135a13d2266e8914a67b3a0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
@@ -3929,46 +4580,51 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2020-08-17T10:01:29+00:00"
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3"
+                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
-                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/5f03a781d984aae42cebd18e7912fa80f02ee644",
+                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644",
                 "shasum": ""
             },
             "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
-            "type": "library",
+            "type": "metapackage",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
                 }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3992,29 +4648,46 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php70/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "639447d008615574653fb3bc60d1986d7172eaae"
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/639447d008615574653fb3bc60d1986d7172eaae",
-                "reference": "639447d008615574653fb3bc60d1986d7172eaae",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cede45fcdfabdd6043b3592e83678e42ec69e930",
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4051,29 +4724,46 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca"
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
-                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/8ff431c517be11c78c48a39a66d37431e26a6bed",
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4113,20 +4803,37 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1864216226af21eb76d9477f691e7cbf198e0402"
+                "reference": "f00872c3f6804150d6a0f73b4151daab96248101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1864216226af21eb76d9477f691e7cbf198e0402",
-                "reference": "1864216226af21eb76d9477f691e7cbf198e0402",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f00872c3f6804150d6a0f73b4151daab96248101",
+                "reference": "f00872c3f6804150d6a0f73b4151daab96248101",
                 "shasum": ""
             },
             "require": {
@@ -4134,11 +4841,6 @@
                 "symfony/polyfill-php80": "^1.15"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
@@ -4163,20 +4865,37 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-07-23T08:36:24+00:00"
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
@@ -4189,7 +4908,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4225,20 +4944,37 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "0f7c58cf81dbb5dd67d423a89d577524a2ec0323"
+                "reference": "3d9f57c89011f0266e6b1d469e5c0110513859d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/0f7c58cf81dbb5dd67d423a89d577524a2ec0323",
-                "reference": "0f7c58cf81dbb5dd67d423a89d577524a2ec0323",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/3d9f57c89011f0266e6b1d469e5c0110513859d5",
+                "reference": "3d9f57c89011f0266e6b1d469e5c0110513859d5",
                 "shasum": ""
             },
             "require": {
@@ -4246,11 +4982,6 @@
                 "symfony/service-contracts": "^1.0|^2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Stopwatch\\": ""
@@ -4275,20 +5006,37 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2020-05-20T17:43:50+00:00"
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "b43a3905262bcf97b2510f0621f859ca4f5287be"
+                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b43a3905262bcf97b2510f0621f859ca4f5287be",
-                "reference": "b43a3905262bcf97b2510f0621f859ca4f5287be",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
+                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
                 "shasum": ""
             },
             "require": {
@@ -4315,11 +5063,6 @@
                 "Resources/bin/var-dump-server"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "Resources/functions/dump.php"
@@ -4351,7 +5094,24 @@
                 "debug",
                 "dump"
             ],
-            "time": "2020-08-17T07:42:30+00:00"
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v5.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-27T10:11:13+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -4413,6 +5173,10 @@
                 "pdf417",
                 "qrcode"
             ],
+            "support": {
+                "issues": "https://github.com/tecnickcom/TCPDF/issues",
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.3.5"
+            },
             "time": "2020-02-14T14:20:12+00:00"
         },
         {
@@ -4453,6 +5217,16 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
@@ -4502,6 +5276,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         }
     ],
@@ -4511,7 +5289,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2"
+        "php": "^7.4"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Constraint/ValidCreditorInformationPaymentReferenceCombination.php
+++ b/src/Constraint/ValidCreditorInformationPaymentReferenceCombination.php
@@ -6,9 +6,9 @@ use Symfony\Component\Validator\Constraint;
 
 class ValidCreditorInformationPaymentReferenceCombination extends Constraint
 {
-    public $message = 'The payment reference type "{{ referenceType }}" does not match with the iban type of "{{ iban }}".';
+    public string $message = 'The payment reference type "{{ referenceType }}" does not match with the iban type of "{{ iban }}".';
 
-    public function getTargets()
+    public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Constraint/ValidCreditorInformationPaymentReferenceCombinationValidator.php
+++ b/src/Constraint/ValidCreditorInformationPaymentReferenceCombinationValidator.php
@@ -33,10 +33,6 @@ class ValidCreditorInformationPaymentReferenceCombinationValidator extends Const
             return;
         }
 
-        if (null === $creditorInformation->getIban() || null === $paymentReference->getType()) {
-            return;
-        }
-
         if (self::QR_IBAN_IS_ALLOWED[$paymentReference->getType()] !== $creditorInformation->containsQrIban()) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ referenceType }}', $paymentReference->getType())

--- a/src/Constraint/ValidCreditorReference.php
+++ b/src/Constraint/ValidCreditorReference.php
@@ -6,5 +6,5 @@ use Symfony\Component\Validator\Constraint;
 
 class ValidCreditorReference extends Constraint
 {
-    public $message = 'The string "{{ string }}" is not a valid Creditor Reference.';
+    public string $message = 'The string "{{ string }}" is not a valid Creditor Reference.';
 }

--- a/src/Constraint/ValidCreditorReferenceValidator.php
+++ b/src/Constraint/ValidCreditorReferenceValidator.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class ValidCreditorReferenceValidator extends ConstraintValidator
 {
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof ValidCreditorReference) {
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\ValidCreditorReference');

--- a/src/DataGroup/Element/AdditionalInformation.php
+++ b/src/DataGroup/Element/AdditionalInformation.php
@@ -12,33 +12,33 @@ class AdditionalInformation implements QrCodeableInterface, SelfValidatableInter
 {
     use SelfValidatableTrait;
 
-    const TRAILER_EPD = 'EPD';
+    public const TRAILER_EPD = 'EPD';
 
     /**
      * Unstructured information can be used to indicate the payment purpose
      * or for additional textual information about payments with a structured reference.
-     *
-     * @var string
      */
-    private $message;
+    private ?string $message;
 
     /**
      * Bill information contains coded information for automated booking of the payment.
      * The data is not forwarded with the payment.
-     *
-     * @var string
      */
-    private $billInformation;
+    private ?string $billInformation;
+
+    private function __construct(
+        ?string $message,
+        ?string $billInformation
+    ) {
+        $this->message = $message;
+        $this->billInformation = $billInformation;
+    }
 
     public static function create(
         ?string $message,
         ?string $billInformation = null
     ): self {
-        $additionalInformation = new self();
-        $additionalInformation->message = $message;
-        $additionalInformation->billInformation = $billInformation;
-
-        return $additionalInformation;
+        return new self($message, $billInformation);
     }
 
     public function getMessage(): ?string

--- a/src/DataGroup/Element/AlternativeScheme.php
+++ b/src/DataGroup/Element/AlternativeScheme.php
@@ -14,20 +14,20 @@ class AlternativeScheme implements QrCodeableInterface, SelfValidatableInterface
 
     /**
      * Parameter character chain of the alternative scheme
-     *
-     * @var string
      */
-    private $parameter;
+    private string $parameter;
+
+    private function __construct(string $parameter)
+    {
+        $this->parameter = $parameter;
+    }
 
     public static function create(string $parameter): self
     {
-        $alternativeScheme = new self();
-        $alternativeScheme->parameter = $parameter;
-
-        return $alternativeScheme;
+        return new self($parameter);
     }
 
-    public function getParameter(): ?string
+    public function getParameter(): string
     {
         return $this->parameter;
     }

--- a/src/DataGroup/Element/CombinedAddress.php
+++ b/src/DataGroup/Element/CombinedAddress.php
@@ -13,39 +13,43 @@ class CombinedAddress implements AddressInterface, SelfValidatableInterface, QrC
 {
     use SelfValidatableTrait;
 
-    const ADDRESS_TYPE = 'K';
+    public const ADDRESS_TYPE = 'K';
 
     /**
      * Name or company
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * Address line 1
      *
      * Street and building number or P.O. Box
-     *
-     * @var string
      */
-    private $addressLine1;
+    private ?string $addressLine1;
 
     /**
      * Address line 2
      *
      * Postal code and town
-     *
-     * @var string
      */
-    private $addressLine2;
+    private string $addressLine2;
 
     /**
      * Country (ISO 3166-1 alpha-2)
-     *
-     * @var string
      */
-    private $country;
+    private string $country;
+
+    private function __construct(
+        string $name,
+        ?string $addressLine1,
+        string $addressLine2,
+        string $country
+    ) {
+        $this->name = $name;
+        $this->addressLine1 = $addressLine1;
+        $this->addressLine2 = $addressLine2;
+        $this->country = strtoupper($country);
+    }
 
     public static function create(
         string $name,
@@ -53,16 +57,15 @@ class CombinedAddress implements AddressInterface, SelfValidatableInterface, QrC
         string $addressLine2,
         string $country
     ): self {
-        $combinedAddress = new self();
-        $combinedAddress->name = $name;
-        $combinedAddress->addressLine1 = $addressLine1;
-        $combinedAddress->addressLine2 = $addressLine2;
-        $combinedAddress->country = strtoupper($country);
-
-        return $combinedAddress;
+        return new self(
+            $name,
+            $addressLine1,
+            $addressLine2,
+            $country
+        );
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
@@ -72,12 +75,12 @@ class CombinedAddress implements AddressInterface, SelfValidatableInterface, QrC
         return $this->addressLine1;
     }
 
-    public function getAddressLine2(): ?string
+    public function getAddressLine2(): string
     {
         return $this->addressLine2;
     }
 
-    public function getCountry(): ?string
+    public function getCountry(): string
     {
         return $this->country;
     }

--- a/src/DataGroup/Element/CreditorInformation.php
+++ b/src/DataGroup/Element/CreditorInformation.php
@@ -14,30 +14,26 @@ class CreditorInformation implements QrCodeableInterface, SelfValidatableInterfa
 
     /**
      * IBAN or QR-IBAN of the creditor
-     *
-     * @var string
      */
-    private $iban;
+    private string $iban;
+
+    private function __construct(string $iban)
+    {
+        $this->iban = (string) preg_replace('/\s+/', '', $iban);
+    }
 
     public static function create(string $iban): self
     {
-        $creditorInformation = new self();
-        $creditorInformation->iban = preg_replace('/\s+/', '', $iban);
-
-        return $creditorInformation;
+        return new self($iban);
     }
 
-    public function getIban(): ?string
+    public function getIban(): string
     {
         return $this->iban;
     }
 
-    public function getFormattedIban(): ?string
+    public function getFormattedIban(): string
     {
-        if (null === $this->iban) {
-            return null;
-        }
-
         return trim(chunk_split($this->iban, 4, ' '));
     }
 

--- a/src/DataGroup/Element/EmptyAdditionalInformation.php
+++ b/src/DataGroup/Element/EmptyAdditionalInformation.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Sprain\SwissQrBill\DataGroup\Element;
+
+use Sprain\SwissQrBill\DataGroup\QrCodeableInterface;
+
+class EmptyAdditionalInformation implements QrCodeableInterface
+{
+    public const TRAILER_EPD = 'EPD';
+
+    public function getQrCodeData(): array
+    {
+        return [
+            null,
+            self::TRAILER_EPD,
+            null
+        ];
+    }
+}

--- a/src/DataGroup/Element/EmptyAddress.php
+++ b/src/DataGroup/Element/EmptyAddress.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Sprain\SwissQrBill\DataGroup\Element;
+
+use Sprain\SwissQrBill\DataGroup\QrCodeableInterface;
+
+class EmptyAddress implements QrCodeableInterface
+{
+    public const ADDRESS_TYPE = '';
+
+    public function getQrCodeData(): array
+    {
+        return [
+            self::ADDRESS_TYPE,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ];
+    }
+}

--- a/src/DataGroup/Element/Header.php
+++ b/src/DataGroup/Element/Header.php
@@ -12,55 +12,51 @@ class Header implements QrCodeableInterface, SelfValidatableInterface
 {
     use SelfValidatableTrait;
 
-    const QRTYPE_SPC = 'SPC';
-    const VERSION_0200 = '0200';
-    const CODING_LATIN = 1;
+    public const QRTYPE_SPC = 'SPC';
+    public const VERSION_0200 = '0200';
+    public const CODING_LATIN = 1;
 
     /**
      * Unambiguous indicator for the Swiss QR code.
-     *
-     * @var string
      */
-    private $qrType;
+    private string $qrType;
 
     /**
      * Version of the specifications (Implementation Guidelines) in use on
      * the date on which the Swiss QR code was created.
      * The first two positions indicate the main version, the following the
      * two positions the sub-version ("0200" for version 2.0).
-     *
-     * @var string
      */
-    private $version;
+    private string $version;
 
     /**
      * Character set code
-     *
-     * @var int
      */
-    private $coding;
+    private int $coding;
+
+    private function __construct(string $qrType, string $version, int $coding)
+    {
+        $this->qrType = $qrType;
+        $this->version = $version;
+        $this->coding = $coding;
+    }
 
     public static function create(string $qrType, string $version, int $coding): self
     {
-        $header = new self();
-        $header->coding = $coding;
-        $header->qrType = $qrType;
-        $header->version = $version;
-
-        return $header;
+        return new self($qrType, $version, $coding);
     }
 
-    public function getQrType(): ?string
+    public function getQrType(): string
     {
         return $this->qrType;
     }
 
-    public function getVersion(): ?string
+    public function getVersion(): string
     {
         return $this->version;
     }
 
-    public function getCoding(): ?int
+    public function getCoding(): int
     {
         return $this->coding;
     }

--- a/src/DataGroup/Element/PaymentAmountInformation.php
+++ b/src/DataGroup/Element/PaymentAmountInformation.php
@@ -12,30 +12,28 @@ class PaymentAmountInformation implements QrCodeableInterface, SelfValidatableIn
 {
     use SelfValidatableTrait;
 
-    const CURRENCY_CHF = 'CHF';
-    const CURRENCY_EUR = 'EUR';
+    public const CURRENCY_CHF = 'CHF';
+    public const CURRENCY_EUR = 'EUR';
 
     /**
      * The payment amount due
-     *
-     * @var float
      */
-    private $amount;
+    private ?float $amount;
 
     /**
      * Payment currency code (ISO 4217)
-     *
-     * @var string
      */
-    private $currency;
+    private string $currency;
+
+    private function __construct(string $currency, ?float $amount)
+    {
+        $this->currency = strtoupper($currency);
+        $this->amount = $amount;
+    }
 
     public static function create(string $currency, ?float $amount = null): self
     {
-        $paymentInformation = new self();
-        $paymentInformation->currency = strtoupper($currency);
-        $paymentInformation->amount = $amount;
-
-        return $paymentInformation;
+        return new self($currency, $amount);
     }
 
     public function getAmount(): ?float
@@ -57,7 +55,7 @@ class PaymentAmountInformation implements QrCodeableInterface, SelfValidatableIn
         );
     }
 
-    public function getCurrency(): ?string
+    public function getCurrency(): string
     {
         return $this->currency;
     }

--- a/src/DataGroup/Element/PaymentReference.php
+++ b/src/DataGroup/Element/PaymentReference.php
@@ -15,43 +15,35 @@ class PaymentReference implements GroupSequenceProviderInterface, QrCodeableInte
 {
     use SelfValidatableTrait;
 
-    const TYPE_QR = 'QRR';
-    const TYPE_SCOR = 'SCOR';
-    const TYPE_NON = 'NON';
+    public const TYPE_QR = 'QRR';
+    public const TYPE_SCOR = 'SCOR';
+    public const TYPE_NON = 'NON';
 
     /**
      * Reference type
-     *
-     * @var string
      */
-    private $type;
+    private string $type;
 
     /**
      * Structured reference number
      * Either a QR reference or a Creditor Reference (ISO 11649)
-     *
-     * @var string|null
      */
-    private $reference;
+    private ?string $reference;
+
+    private function __construct(string $type, ?string $reference)
+    {
+        $this->type = $type;
+        $this->reference = $reference;
+
+        $this->handleWhiteSpaceInReference();
+    }
 
     public static function create(string $type, ?string $reference = null): self
     {
-        $paymentReference = new self();
-        $paymentReference->type = $type;
-        $paymentReference->reference = $reference;
-
-        if (null !== $paymentReference->reference) {
-            $paymentReference->reference = StringModifier::stripWhitespace($paymentReference->reference);
-        }
-
-        if ('' === ($paymentReference->reference)) {
-            $paymentReference->reference = null;
-        }
-
-        return $paymentReference;
+        return new self($type, $reference);
     }
 
-    public function getType(): ?string
+    public function getType(): string
     {
         return $this->type;
     }
@@ -129,5 +121,16 @@ class PaymentReference implements GroupSequenceProviderInterface, QrCodeableInte
         ];
 
         return $groups;
+    }
+
+    private function handleWhiteSpaceInReference(): void
+    {
+        if (null !== $this->reference) {
+            $this->reference = StringModifier::stripWhitespace($this->reference);
+        }
+
+        if ('' === ($this->reference)) {
+            $this->reference = null;
+        }
     }
 }

--- a/src/DataGroup/Element/PaymentReference.php
+++ b/src/DataGroup/Element/PaymentReference.php
@@ -115,12 +115,10 @@ class PaymentReference implements GroupSequenceProviderInterface, QrCodeableInte
 
     public function getGroupSequence()
     {
-        $groups = [
+        return [
             'default',
             $this->getType()
         ];
-
-        return $groups;
     }
 
     private function handleWhiteSpaceInReference(): void

--- a/src/DataGroup/Element/StructuredAddress.php
+++ b/src/DataGroup/Element/StructuredAddress.php
@@ -13,51 +13,55 @@ class StructuredAddress implements AddressInterface, SelfValidatableInterface, Q
 {
     use SelfValidatableTrait;
 
-    const ADDRESS_TYPE = 'S';
+    public const ADDRESS_TYPE = 'S';
 
     /**
      * Name or company
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * Street / P.O. box
      *
      * May not include building or house number.
-     *
-     * @var string
      */
-    private $street;
+    private ?string $street;
 
     /**
      * Building number
-     *
-     * @var string
      */
-    private $buildingNumber;
+    private ?string $buildingNumber;
 
     /**
      * Postal code without county code
-     *
-     * @var string
      */
-    private $postalCode;
+    private string $postalCode;
 
     /**
      * City
-     *
-     * @var string
      */
-    private $city;
+    private string $city;
 
     /**
      * Country (ISO 3166-1 alpha-2)
-     *
-     * @var string
      */
-    private $country;
+    private string $country;
+
+    private function __construct(
+        string $name,
+        ?string $street,
+        ?string $buildingNumber,
+        string $postalCode,
+        string $city,
+        string $country
+    ) {
+        $this->name = $name;
+        $this->street = $street;
+        $this->buildingNumber = $buildingNumber;
+        $this->postalCode = $postalCode;
+        $this->city = $city;
+        $this->country = strtoupper($country);
+    }
 
     public static function createWithoutStreet(
         string $name,
@@ -65,13 +69,14 @@ class StructuredAddress implements AddressInterface, SelfValidatableInterface, Q
         string $city,
         string $country
     ): self {
-        $structuredAddress = new self();
-        $structuredAddress->name = $name;
-        $structuredAddress->postalCode = $postalCode;
-        $structuredAddress->city = $city;
-        $structuredAddress->country = strtoupper($country);
-
-        return $structuredAddress;
+        return new self(
+            $name,
+            null,
+            null,
+            $postalCode,
+            $city,
+            $country
+        );
     }
 
     public static function createWithStreet(
@@ -82,18 +87,17 @@ class StructuredAddress implements AddressInterface, SelfValidatableInterface, Q
         string $city,
         string $country
     ): self {
-        $structuredAddress = new self();
-        $structuredAddress->name = $name;
-        $structuredAddress->street = $street;
-        $structuredAddress->buildingNumber = $buildingNumber;
-        $structuredAddress->postalCode = $postalCode;
-        $structuredAddress->city = $city;
-        $structuredAddress->country = strtoupper($country);
-
-        return $structuredAddress;
+        return new self(
+            $name,
+            $street,
+            $buildingNumber,
+            $postalCode,
+            $city,
+            $country
+        );
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
@@ -108,17 +112,17 @@ class StructuredAddress implements AddressInterface, SelfValidatableInterface, Q
         return $this->buildingNumber;
     }
 
-    public function getPostalCode(): ?string
+    public function getPostalCode(): string
     {
         return $this->postalCode;
     }
 
-    public function getCity(): ?string
+    public function getCity(): string
     {
         return $this->city;
     }
 
-    public function getCountry(): ?string
+    public function getCountry(): string
     {
         return $this->country;
     }

--- a/src/PaymentPart/Output/AbstractOutput.php
+++ b/src/PaymentPart/Output/AbstractOutput.php
@@ -11,17 +11,10 @@ use Sprain\SwissQrBill\QrCode\QrCode;
 
 abstract class AbstractOutput
 {
-    /** @var QrBill */
-    protected $qrBill;
-
-    /** @var  string */
-    protected $language;
-
-    /** @var bool */
-    protected $printable;
-
-    /** @var string */
-    protected $qrCodeImageFormat;
+    protected QrBill $qrBill;
+    protected string $language;
+    protected bool $printable;
+    protected string $qrCodeImageFormat;
 
     public function __construct(QrBill $qrBill, string $language)
     {

--- a/src/PaymentPart/Output/Element/Placeholder.php
+++ b/src/PaymentPart/Output/Element/Placeholder.php
@@ -39,20 +39,11 @@ class Placeholder implements OutputElementInterface
         'height' => 10
     ];
 
-    /** @var string */
-    private $type;
-
-    /** @var string */
-    private $fileSvg;
-
-    /** @var string */
-    private $filePng;
-
-    /** @var int */
-    private $width;
-
-    /** @var int */
-    private $height;
+    private string $type;
+    private string $fileSvg;
+    private string $filePng;
+    private int $width;
+    private int $height;
 
     public static function create(array $type): self
     {

--- a/src/PaymentPart/Output/Element/Text.php
+++ b/src/PaymentPart/Output/Element/Text.php
@@ -4,7 +4,7 @@ namespace Sprain\SwissQrBill\PaymentPart\Output\Element;
 
 class Text implements OutputElementInterface
 {
-    private $text;
+    private string $text;
 
     public static function create(string $text): self
     {
@@ -14,7 +14,7 @@ class Text implements OutputElementInterface
         return $element;
     }
 
-    public function getText(): ?string
+    public function getText(): string
     {
         return $this->text;
     }

--- a/src/PaymentPart/Output/Element/Title.php
+++ b/src/PaymentPart/Output/Element/Title.php
@@ -4,7 +4,7 @@ namespace Sprain\SwissQrBill\PaymentPart\Output\Element;
 
 class Title implements OutputElementInterface
 {
-    private $title;
+    private string $title;
 
     public static function create(string $title): self
     {
@@ -14,7 +14,7 @@ class Title implements OutputElementInterface
         return $element;
     }
 
-    public function getTitle(): ?string
+    public function getTitle(): string
     {
         return $this->title;
     }

--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -273,17 +273,17 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         );
     }
 
-    private function setX(float $x) : void
+    private function setX(float $x): void
     {
         $this->fpdf->SetX($x + $this->offsetX);
     }
 
-    private function setY(float $y) : void
+    private function setY(float $y): void
     {
         $this->fpdf->SetY($y + $this->offsetY);
     }
 
-    private function SetXY(float $x, float $y) : void
+    private function SetXY(float $x, float $y): void
     {
         $this->fpdf->SetXY($x + $this->offsetX, $y + $this->offsetY);
     }

--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -17,14 +17,14 @@ use Sprain\SwissQrBill\QrCode\QrCode;
 
 final class FpdfOutput extends AbstractOutput implements OutputInterface
 {
-    // FPDF constants
+    // FPDF
     private const BORDER = 0;
     private const ALIGN_LEFT = 'L';
     private const ALIGN_RIGHT = 'R';
     private const ALIGN_CENTER = 'C';
     private const FONT = 'Helvetica';
 
-    // Location constants
+    // Location
     private const CURRENCY_AMOUNT_Y = 259.3;
     private const AMOUNT_LINE_SPACING = 1.2;
     private const AMOUNT_LINE_SPACING_RCPT = 0.6;
@@ -33,7 +33,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
     private const RIGHT_PART_X_INFO = 117;
     private const TITLE_Y = 195.2;
 
-    // Font constants
+    // Font size
     private const FONT_SIZE_MAIN_TITLE = 11;
     private const FONT_SIZE_TITLE_RECEIPT = 6;
     private const FONT_SIZE_RECEIPT = 8;
@@ -41,21 +41,14 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
     private const FONT_SIZE_PAYMENT_PART = 10;
     private const FONT_SIZE_FURTHER_INFORMATION = 7;
 
-    // Line spacing constants
+    // Line spacing
     private const LINE_SPACING_RECEIPT = 3.4;
     private const LINE_SPACING_PAYMENT_PART = 4.8;
+    private float $amountLS = 0;
 
-    /** @var Fpdf */
-    private $fpdf;
-
-    /** @var float */
-    private $amountLS = 0;
-
-    /* @var float */
-    private $offsetX;
-
-    /* @var float */
-    private $offsetY;
+    private Fpdf $fpdf;
+    private float $offsetX;
+    private float $offsetY;
 
     public function __construct(
         QrBill $qrBill,

--- a/src/PaymentPart/Output/HtmlOutput/HtmlOutput.php
+++ b/src/PaymentPart/Output/HtmlOutput/HtmlOutput.php
@@ -135,9 +135,9 @@ final class HtmlOutput extends AbstractOutput implements OutputInterface
     }
 
     /**
-     * @param Title|Text|Placeholder $element Instance of OutputElementInterface.
+     * @param Title|Text|Placeholder $element
      */
-    private function getContentElement($element): string
+    private function getContentElement(OutputElementInterface $element): string
     {
         if ($element instanceof Title) {
             $elementTemplate = TitleElementTemplate::TEMPLATE;

--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -305,12 +305,12 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
         );
     }
 
-    private function setX(int $x) : void
+    private function setX(int $x): void
     {
         $this->tcPdf->SetX($x+$this->offsetX);
     }
 
-    private function setY(int $y) : void
+    private function setY(int $y): void
     {
         $this->tcPdf->SetY($y+$this->offsetY);
     }
@@ -321,7 +321,7 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
         int $h = 0,
         int $nextLineAlign = 0,
         string $textAlign = self::ALIGN_LEFT
-    ) : void {
+    ): void {
         $this->tcPdf->Cell($w, $h, $text, self::BORDER, $nextLineAlign, $textAlign);
     }
 
@@ -331,11 +331,11 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
         int $h = 0,
         int $nextLineAlign = 0,
         string $textAlign = self::ALIGN_LEFT
-    ) : void {
+    ): void {
         $this->tcPdf->MultiCell($w, $h, $text, self::BORDER, $textAlign, false, $nextLineAlign);
     }
 
-    private function printLine(int $x1, int $y1, int $x2, int $y2) : void
+    private function printLine(int $x1, int $y1, int $x2, int $y2): void
     {
         $this->tcPdf->Line($x1+$this->offsetX, $y1+$this->offsetY, $x2+$this->offsetX, $y2+$this->offsetY);
     }

--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -8,7 +8,6 @@ use Sprain\SwissQrBill\PaymentPart\Output\Element\Placeholder;
 use Sprain\SwissQrBill\PaymentPart\Output\Element\Text;
 use Sprain\SwissQrBill\PaymentPart\Output\Element\Title;
 use Sprain\SwissQrBill\PaymentPart\Output\OutputInterface;
-use Sprain\SwissQrBill\QrCode\Exception\UnsupportedFileExtensionException;
 use Sprain\SwissQrBill\QrCode\QrCode;
 use Sprain\SwissQrBill\PaymentPart\Translation\Translation;
 use Sprain\SwissQrBill\QrBill;
@@ -16,7 +15,7 @@ use TCPDF;
 
 final class TcPdfOutput extends AbstractOutput implements OutputInterface
 {
-    // TCPDF constants
+    // TCPDF
     private const BORDER = 0;
     private const ALIGN_BELOW = 2;
     private const ALIGN_LEFT = 'L';
@@ -24,20 +23,20 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
     private const ALIGN_CENTER = 'C';
     private const FONT = 'Helvetica';
 
-    // Ratio constants
+    // Ratio
     private const LEFT_CELL_HEIGHT_RATIO_COMMON = 1.2;
     private const RIGHT_CELL_HEIGHT_RATIO_COMMON = 1.1;
     private const LEFT_CELL_HEIGHT_RATIO_CURRENCY_AMOUNT = 1.5;
     private const RIGHT_CELL_HEIGHT_RATIO_CURRENCY_AMOUNT = 1.5;
 
-    // Location constants
+    // Location
     private const CURRENCY_AMOUNT_Y = 259;
     private const LEFT_PART_X = 4;
     private const RIGHT_PART_X = 66;
     private const RIGHT_PART_X_INFO = 117;
     private const TITLE_Y = 195;
 
-    // Font constants
+    // Font
     private const FONT_SIZE_MAIN_TITLE = 11;
     private const FONT_SIZE_TITLE_RECEIPT = 6;
     private const FONT_SIZE_RECEIPT = 8;
@@ -45,24 +44,13 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
     private const FONT_SIZE_PAYMENT_PART = 10;
     private const FONT_SIZE_FURTHER_INFORMATION = 7;
 
-    // Line spacing constants
+    // Line spacing
     private const LINE_SPACING_RECEIPT = 3.5;
     private const LINE_SPACING_PAYMENT_PART = 4.8;
 
-    /** @var string */
-    protected $language;
-
-    /** @var QrBill */
-    protected $qrBill;
-
-    /* @var TCPDF */
-    private $tcPdf;
-
-    /* @var float */
-    private $offsetX;
-
-    /* @var float */
-    private $offsetY;
+    private TCPDF $tcPdf;
+    private float $offsetX;
+    private float $offsetY;
 
     public function __construct(
         QrBill $qrBill,

--- a/src/QrBill.php
+++ b/src/QrBill.php
@@ -46,7 +46,8 @@ class QrBill implements SelfValidatableInterface
     private array $alternativeSchemes;
     private string $errorCorrectionLevel;
 
-    private function __construct(Header $header) {
+    private function __construct(Header $header)
+    {
         $this->header = $header;
         $this->creditorInformation = null;
         $this->creditor = null;

--- a/src/QrBill.php
+++ b/src/QrBill.php
@@ -70,7 +70,7 @@ class QrBill implements SelfValidatableInterface
         return new self($header);
     }
 
-    public function getHeader(): ?Header
+    public function getHeader(): Header
     {
         return $this->header;
     }

--- a/src/QrBill.php
+++ b/src/QrBill.php
@@ -8,6 +8,8 @@ use Sprain\SwissQrBill\DataGroup\AddressInterface;
 use Sprain\SwissQrBill\DataGroup\Element\AdditionalInformation;
 use Sprain\SwissQrBill\DataGroup\Element\AlternativeScheme;
 use Sprain\SwissQrBill\DataGroup\Element\CreditorInformation;
+use Sprain\SwissQrBill\DataGroup\Element\EmptyAdditionalInformation;
+use Sprain\SwissQrBill\DataGroup\Element\EmptyAddress;
 use Sprain\SwissQrBill\DataGroup\Element\Header;
 use Sprain\SwissQrBill\DataGroup\Element\PaymentAmountInformation;
 use Sprain\SwissQrBill\DataGroup\Element\PaymentReference;
@@ -215,11 +217,11 @@ class QrBill implements SelfValidatableInterface
             $this->getHeader(),
             $this->getCreditorInformation(),
             $this->getCreditor(),
-            new StructuredAddress(), # Placeholder for ultimateCreditor, which is currently not yet allowed to be used by the implementation guidelines
+            new EmptyAddress(), # Placeholder for ultimateCreditor, which is currently not yet allowed to be used by the implementation guidelines
             $this->getPaymentAmountInformation(),
-            $this->getUltimateDebtor() ?: new StructuredAddress(),
+            $this->getUltimateDebtor() ?: new EmptyAddress(),
             $this->getPaymentReference(),
-            $this->getAdditionalInformation() ?: new AdditionalInformation(),
+            $this->getAdditionalInformation() ?: new EmptyAdditionalInformation(),
             $this->getAlternativeSchemes()
         ];
 

--- a/src/QrCode/QrCode.php
+++ b/src/QrCode/QrCode.php
@@ -8,12 +8,12 @@ use Sprain\SwissQrBill\QrCode\Exception\UnsupportedFileExtensionException;
 
 class QrCode extends BaseQrCode implements QrCodeInterface
 {
-    const FILE_FORMAT_PNG = 'png';
-    const FILE_FORMAT_SVG = 'svg';
+    public const FILE_FORMAT_PNG = 'png';
+    public const FILE_FORMAT_SVG = 'svg';
 
     // A file extension is supported if the underlying library supports it,
     // including the possibility to add a logo in the center of the qr code.
-    const SUPPORTED_FILE_FORMATS = [
+    private const SUPPORTED_FILE_FORMATS = [
         self::FILE_FORMAT_PNG,
         self::FILE_FORMAT_SVG
     ];

--- a/src/Reference/QrPaymentReferenceGenerator.php
+++ b/src/Reference/QrPaymentReferenceGenerator.php
@@ -14,11 +14,8 @@ class QrPaymentReferenceGenerator implements SelfValidatableInterface
 {
     use SelfValidatableTrait;
 
-    /** @var string */
-    private $customerIdentificationNumber;
-
-    /** @var string */
-    private $referenceNumber;
+    private ?string $customerIdentificationNumber = null;
+    private string $referenceNumber;
 
     public static function generate(?string $customerIdentificationNumber, string $referenceNumber): string
     {

--- a/src/Reference/RfCreditorReferenceGenerator.php
+++ b/src/Reference/RfCreditorReferenceGenerator.php
@@ -14,8 +14,7 @@ class RfCreditorReferenceGenerator implements SelfValidatableInterface
 {
     use SelfValidatableTrait;
 
-    /** @var string */
-    protected $reference;
+    private string $reference;
 
     public static function generate(string $reference) : string
     {

--- a/src/Reference/RfCreditorReferenceGenerator.php
+++ b/src/Reference/RfCreditorReferenceGenerator.php
@@ -16,7 +16,7 @@ class RfCreditorReferenceGenerator implements SelfValidatableInterface
 
     private string $reference;
 
-    public static function generate(string $reference) : string
+    public static function generate(string $reference): string
     {
         $generator = new self($reference);
 
@@ -28,7 +28,7 @@ class RfCreditorReferenceGenerator implements SelfValidatableInterface
         $this->reference = StringModifier::stripWhitespace($reference);
     }
 
-    public function doGenerate() : string
+    public function doGenerate(): string
     {
         if (!$this->isValid()) {
             throw new InvalidCreditorReferenceException(

--- a/src/Validator/SelfValidatableTrait.php
+++ b/src/Validator/SelfValidatableTrait.php
@@ -8,8 +8,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 trait SelfValidatableTrait
 {
-    /** @var ValidatorInterface */
-    private $validator;
+    private ?ValidatorInterface $validator = null;
 
     public function getViolations(): ConstraintViolationListInterface
     {

--- a/tests/Constraints/ValidCreditorInformationPaymentReferenceCombinationTest.php
+++ b/tests/Constraints/ValidCreditorInformationPaymentReferenceCombinationTest.php
@@ -33,21 +33,17 @@ class ValidCreditorInformationPaymentReferenceCombinationTest extends Constraint
     /**
      * @dataProvider emptyQrBillMocksProvider
      */
-    public function testEmptyQrBillValuesAreValid($qrBillMock)
+    public function testEmptyQrBillValuesAreValid(QrBill $qrBillMock)
     {
         $this->validator->validate($qrBillMock, new ValidCreditorInformationPaymentReferenceCombination());
 
         $this->assertNoViolation();
     }
 
-    public function emptyQrBillMocksProvider()
+    public function emptyQrBillMocksProvider(): array
     {
         return [
             [$this->getQrBillMock()],
-            [$this->getQrBillMock(
-                $this->getCreditorInformationMock(),
-                $this->getPaymentReferenceMock()
-            )],
             [$this->getQrBillMock(
                 $this->getCreditorInformationMock(),
                 null
@@ -55,29 +51,21 @@ class ValidCreditorInformationPaymentReferenceCombinationTest extends Constraint
             [$this->getQrBillMock(
                 null,
                 $this->getPaymentReferenceMock()
-            )],
-            [$this->getQrBillMock(
-                $this->getCreditorInformationMock('any-iban'),
-                $this->getPaymentReferenceMock()
-            )],
-            [$this->getQrBillMock(
-                $this->getCreditorInformationMock(),
-                $this->getPaymentReferenceMock(PaymentReference::TYPE_QR)
-            )],
+            )]
         ];
     }
 
     /**
      * @dataProvider validCombinationsQrBillMocksProvider
      */
-    public function testValidCombinations($qrBillMock)
+    public function testValidCombinations(QrBill $qrBillMock)
     {
         $this->validator->validate($qrBillMock, new ValidCreditorInformationPaymentReferenceCombination());
 
         $this->assertNoViolation();
     }
 
-    public function validCombinationsQrBillMocksProvider()
+    public function validCombinationsQrBillMocksProvider(): array
     {
         return [
             [$this->getQrBillMock(
@@ -98,7 +86,7 @@ class ValidCreditorInformationPaymentReferenceCombinationTest extends Constraint
     /**
      * @dataProvider invalidCombinationsQrBillMocksProvider
      */
-    public function testInvalidCombinations($qrBillMock)
+    public function testInvalidCombinations(QrBill $qrBillMock)
     {
         $this->validator->validate($qrBillMock, new ValidCreditorInformationPaymentReferenceCombination([
             'message' => 'myMessage',
@@ -110,7 +98,7 @@ class ValidCreditorInformationPaymentReferenceCombinationTest extends Constraint
             ->assertRaised();
     }
 
-    public function invalidCombinationsQrBillMocksProvider()
+    public function invalidCombinationsQrBillMocksProvider(): array
     {
         return [
             [$this->getQrBillMock(
@@ -128,7 +116,7 @@ class ValidCreditorInformationPaymentReferenceCombinationTest extends Constraint
         ];
     }
 
-    public function getQrBillMock($creditorInformation = null, $paymentReference = null)
+    public function getQrBillMock(?CreditorInformation $creditorInformation = null, ?PaymentReference $paymentReference = null)
     {
         $qrBill = $this->createMock(QrBill::class);
 
@@ -141,7 +129,7 @@ class ValidCreditorInformationPaymentReferenceCombinationTest extends Constraint
         return $qrBill;
     }
 
-    public function getCreditorInformationMock($iban = null, $containsQrIban = false)
+    public function getCreditorInformationMock(string $iban = '', bool $containsQrIban = false)
     {
         $creditorInformation = $this->createMock(CreditorInformation::class);
 
@@ -154,7 +142,7 @@ class ValidCreditorInformationPaymentReferenceCombinationTest extends Constraint
         return $creditorInformation;
     }
 
-    public function getPaymentReferenceMock($paymentReferenceType = null)
+    public function getPaymentReferenceMock(string $paymentReferenceType = '')
     {
         $paymentReference = $this->createMock(PaymentReference::class);
 

--- a/tests/DataGroup/Element/AdditionalInformationTest.php
+++ b/tests/DataGroup/Element/AdditionalInformationTest.php
@@ -10,14 +10,14 @@ class AdditionalInformationTest extends TestCase
     /**
      * @dataProvider messageProvider
      */
-    public function testMessage($numberOfValidations, $value)
+    public function testMessage(int $numberOfValidations, ?string $value): void
     {
         $additionalInformation = AdditionalInformation::create($value);
 
         $this->assertSame($numberOfValidations, $additionalInformation->getViolations()->count());
     }
 
-    public function messageProvider()
+    public function messageProvider(): array
     {
         return [
             [0, '012345678901234567890123456'],
@@ -30,14 +30,14 @@ class AdditionalInformationTest extends TestCase
     /**
      * @dataProvider billInformationProvider
      */
-    public function testBillInformation($numberOfValidations, $value)
+    public function testBillInformation(int $numberOfValidations, ?string $value)
     {
         $additionalInformation = AdditionalInformation::create(null, $value);
 
         $this->assertSame($numberOfValidations, $additionalInformation->getViolations()->count());
     }
 
-    public function billInformationProvider()
+    public function billInformationProvider(): array
     {
         return [
             [0, '012345678901234567890123456'],
@@ -47,7 +47,7 @@ class AdditionalInformationTest extends TestCase
         ];
     }
 
-    public function testFormattedString()
+    public function testFormattedString(): void
     {
         $additionalInformation = AdditionalInformation::create('message');
         $this->assertSame("message", $additionalInformation->getFormattedString());
@@ -56,7 +56,7 @@ class AdditionalInformationTest extends TestCase
         $this->assertSame("message\nbillInformation", $additionalInformation->getFormattedString());
     }
 
-    public function testQrCodeData()
+    public function testQrCodeData(): void
     {
         $additionalInformation = AdditionalInformation::create('message', 'billInformation');
 

--- a/tests/DataGroup/Element/AlternativeSchemeTest.php
+++ b/tests/DataGroup/Element/AlternativeSchemeTest.php
@@ -10,14 +10,14 @@ class AlternativeSchemeTest extends TestCase
     /**
      * @dataProvider parameterProvider
      */
-    public function testParameter($numberOfValidations, $value)
+    public function testParameter(int $numberOfValidations, string $value): void
     {
         $alternativeScheme = AlternativeScheme::create($value);
 
         $this->assertSame($numberOfValidations, $alternativeScheme->getViolations()->count());
     }
 
-    public function parameterProvider()
+    public function parameterProvider(): array
     {
         return [
             [0, '1'],

--- a/tests/DataGroup/Element/CombinedAddressTest.php
+++ b/tests/DataGroup/Element/CombinedAddressTest.php
@@ -10,7 +10,7 @@ class CombinedAddressTest extends TestCase
     /**
      * @dataProvider nameProvider
      */
-    public function testName($numberOfValidations, $value)
+    public function testName($numberOfValidations, $value): void
     {
         $address = CombinedAddress::create(
             $value,
@@ -22,7 +22,7 @@ class CombinedAddressTest extends TestCase
         $this->assertSame($numberOfValidations, $address->getViolations()->count());
     }
 
-    public function nameProvider()
+    public function nameProvider(): array
     {
         return [
             [0, 'A'],
@@ -38,7 +38,7 @@ class CombinedAddressTest extends TestCase
     /**
      * @dataProvider addressLine1Provider
      */
-    public function testAddressLine1($numberOfValidations, $value)
+    public function testAddressLine1(int $numberOfValidations, ?string $value): void
     {
         $address = CombinedAddress::create(
             'Thomas Mustermann',
@@ -50,7 +50,7 @@ class CombinedAddressTest extends TestCase
         $this->assertSame($numberOfValidations, $address->getViolations()->count());
     }
 
-    public function addressLine1Provider()
+    public function addressLine1Provider(): array
     {
         return [
             [0, null],
@@ -66,7 +66,7 @@ class CombinedAddressTest extends TestCase
     /**
      * @dataProvider addressLine2Provider
      */
-    public function testAddressLine2($numberOfValidations, $value)
+    public function testAddressLine2(int $numberOfValidations, string $value): void
     {
         $address = CombinedAddress::create(
             'Thomas Mustermann',
@@ -78,7 +78,7 @@ class CombinedAddressTest extends TestCase
         $this->assertSame($numberOfValidations, $address->getViolations()->count());
     }
 
-    public function addressLine2Provider()
+    public function addressLine2Provider(): array
     {
         return [
             [0, 'A'],
@@ -90,7 +90,7 @@ class CombinedAddressTest extends TestCase
         ];
     }
 
-    public function testQrCodeData()
+    public function testQrCodeData(): void
     {
         $address = CombinedAddress::create(
             'Thomas Mustermann',
@@ -115,7 +115,7 @@ class CombinedAddressTest extends TestCase
     /**
      * @dataProvider countryProvider
      */
-    public function testCountry($numberOfValidations, $value)
+    public function testCountry(int $numberOfValidations, string $value): void
     {
         $address = CombinedAddress::create(
             'Thomas Mustermann',
@@ -127,7 +127,7 @@ class CombinedAddressTest extends TestCase
         $this->assertSame($numberOfValidations, $address->getViolations()->count());
     }
 
-    public function countryProvider()
+    public function countryProvider(): array
     {
         return [
             [0, 'CH'],
@@ -146,12 +146,12 @@ class CombinedAddressTest extends TestCase
     /**
      * @dataProvider addressProvider
      */
-    public function testFullAddressString(CombinedAddress $address, $expected)
+    public function testFullAddressString(CombinedAddress $address, string $expected): void
     {
         $this->assertSame($expected, $address->getFullAddress());
     }
 
-    public function addressProvider()
+    public function addressProvider(): array
     {
         return [
             [

--- a/tests/DataGroup/Element/CreditorInformationTest.php
+++ b/tests/DataGroup/Element/CreditorInformationTest.php
@@ -10,7 +10,7 @@ class CreditorInformationTest extends TestCase
     /**
      * @dataProvider ibanProvider
      */
-    public function testIban($numberOfViolations, $value)
+    public function testIban(int $numberOfViolations, string $value)
     {
         $creditorInformation = CreditorInformation::create(
             $value
@@ -19,7 +19,7 @@ class CreditorInformationTest extends TestCase
         $this->assertSame($numberOfViolations, $creditorInformation->getViolations()->count());
     }
 
-    public function ibanProvider()
+    public function ibanProvider(): array
     {
         return [
             [0, 'CH93 0076 2011 6238 5295 7'],
@@ -58,7 +58,7 @@ class CreditorInformationTest extends TestCase
     /**
      * @dataProvider qrIbanCheckProvider
      */
-    public function testContainsQrIban($isQrIban, $value)
+    public function testContainsQrIban(bool $isQrIban, string $value): void
     {
         $creditorInformation = CreditorInformation::create(
             $value
@@ -67,7 +67,7 @@ class CreditorInformationTest extends TestCase
         $this->assertSame($isQrIban, $creditorInformation->containsQrIban());
     }
 
-    public function qrIbanCheckProvider()
+    public function qrIbanCheckProvider(): array
     {
         return [
             // normal valid IBANs
@@ -88,7 +88,7 @@ class CreditorInformationTest extends TestCase
     /**
      * @dataProvider formattedIbanProvider
      */
-    public function testFormattedIban($iban, $formattedIban)
+    public function testFormattedIban(string $iban, string $formattedIban): void
     {
         $creditorInformation = CreditorInformation::create(
             $iban
@@ -97,7 +97,7 @@ class CreditorInformationTest extends TestCase
         $this->assertSame($formattedIban, $creditorInformation->getFormattedIban());
     }
 
-    public function formattedIbanProvider()
+    public function formattedIbanProvider(): array
     {
         return [
             ['CH93 0076 2011 6238 5295 7', 'CH93 0076 2011 6238 5295 7'],

--- a/tests/DataGroup/Element/HeaderTest.php
+++ b/tests/DataGroup/Element/HeaderTest.php
@@ -10,7 +10,7 @@ class HeaderTest extends TestCase
     /**
      * @dataProvider qrTypeProvider
      */
-    public function testQrType($numberOfViolations, $value)
+    public function testQrType(int $numberOfViolations, string $value): void
     {
         $header = Header::create(
             $value,
@@ -21,7 +21,7 @@ class HeaderTest extends TestCase
         $this->assertSame($numberOfViolations, $header->getViolations()->count());
     }
 
-    public function qrTypeProvider()
+    public function qrTypeProvider(): array
     {
         return [
             [0, 'SPC'],
@@ -45,7 +45,7 @@ class HeaderTest extends TestCase
     /**
      * @dataProvider versionProvider
      */
-    public function testVersionIsValid($numberOfViolations, $value)
+    public function testVersionIsValid(int $numberOfViolations, string $value): void
     {
         $header = Header::create(
             'SPC',
@@ -56,7 +56,7 @@ class HeaderTest extends TestCase
         $this->assertSame($numberOfViolations, $header->getViolations()->count());
     }
 
-    public function versionProvider()
+    public function versionProvider(): array
     {
         return [
             [0, '0200'],
@@ -77,7 +77,7 @@ class HeaderTest extends TestCase
     /**
      * @dataProvider codingProvider
      */
-    public function testCodingIsValid($numberOfViolations, $value)
+    public function testCodingIsValid(int $numberOfViolations, int $value): void
     {
         $header = Header::create(
             'SPC',
@@ -106,7 +106,7 @@ class HeaderTest extends TestCase
         ];
     }
 
-    public function testQrCodeData()
+    public function testQrCodeData(): void
     {
         $header = Header::create(
             'SPC',

--- a/tests/DataGroup/Element/PaymentAmountInformationTest.php
+++ b/tests/DataGroup/Element/PaymentAmountInformationTest.php
@@ -10,7 +10,7 @@ class PaymentAmountInformationTest extends TestCase
     /**
      * @dataProvider amountProvider
      */
-    public function testAmount($numberOfViolations, $value)
+    public function testAmount(int $numberOfViolations, ?float $value): void
     {
         $paymentAmountInformation = PaymentAmountInformation::create(
             'CHF',
@@ -20,7 +20,7 @@ class PaymentAmountInformationTest extends TestCase
         $this->assertSame($numberOfViolations, $paymentAmountInformation->getViolations()->count());
     }
 
-    public function amountProvider()
+    public function amountProvider(): array
     {
         return [
             [0, null],
@@ -37,7 +37,7 @@ class PaymentAmountInformationTest extends TestCase
     /**
      * @dataProvider currencyProvider
      */
-    public function testCurrency($numberOfViolations, $value)
+    public function testCurrency(int $numberOfViolations, string $value): void
     {
         $paymentAmountInformation = PaymentAmountInformation::create(
             $value,
@@ -47,7 +47,7 @@ class PaymentAmountInformationTest extends TestCase
         $this->assertSame($numberOfViolations, $paymentAmountInformation->getViolations()->count());
     }
 
-    public function currencyProvider()
+    public function currencyProvider(): array
     {
         return [
             [0, 'CHF'],
@@ -64,7 +64,7 @@ class PaymentAmountInformationTest extends TestCase
     /**
      * @dataProvider formattedAmountProvider
      */
-    public function testFormattedAmount($amount, $formattedAmount)
+    public function testFormattedAmount(float $amount, string $formattedAmount)
     {
         $paymentAmountInformation = PaymentAmountInformation::create(
             'CHF',
@@ -74,7 +74,7 @@ class PaymentAmountInformationTest extends TestCase
         $this->assertSame($formattedAmount, $paymentAmountInformation->getFormattedAmount());
     }
 
-    public function formattedAmountProvider()
+    public function formattedAmountProvider(): array
     {
         return [
             [0, '0.00'],
@@ -86,7 +86,7 @@ class PaymentAmountInformationTest extends TestCase
         ];
     }
 
-    public function testQrCodeData()
+    public function testQrCodeData(): void
     {
         $paymentAmountInformation = PaymentAmountInformation::create(
             'CHF',

--- a/tests/DataGroup/Element/PaymentReferenceTest.php
+++ b/tests/DataGroup/Element/PaymentReferenceTest.php
@@ -10,7 +10,7 @@ class PaymentReferenceTest extends TestCase
     /**
      * @dataProvider qrReferenceProvider
      */
-    public function testQrReference(int $numberOfViolations, ?string $value)
+    public function testQrReference(int $numberOfViolations, ?string $value): void
     {
         $paymentReference = PaymentReference::create(
             PaymentReference::TYPE_QR,
@@ -37,7 +37,7 @@ class PaymentReferenceTest extends TestCase
     /**
      * @dataProvider scorReferenceProvider
      */
-    public function testScorReference($numberOfViolations, $value)
+    public function testScorReference(int $numberOfViolations, ?string $value): void
     {
         $paymentReference = PaymentReference::create(
             PaymentReference::TYPE_SCOR,
@@ -47,7 +47,7 @@ class PaymentReferenceTest extends TestCase
         $this->assertSame($numberOfViolations, $paymentReference->getViolations()->count());
     }
 
-    public function scorReferenceProvider()
+    public function scorReferenceProvider(): array
     {
         return [
             [0, 'RF18539007547034'],
@@ -64,7 +64,7 @@ class PaymentReferenceTest extends TestCase
     /**
      * @dataProvider nonReferenceProvider
      */
-    public function testNonReference($numberOfViolations, $value)
+    public function testNonReference(int $numberOfViolations, ?string $value): void
     {
         $paymentReference = PaymentReference::create(
             PaymentReference::TYPE_NON,
@@ -87,7 +87,7 @@ class PaymentReferenceTest extends TestCase
     /**
      * @dataProvider formattedReferenceProvider
      */
-    public function testFormattedReference($type, $reference, $formattedReference)
+    public function testFormattedReference(string $type, ?string  $reference, ?string  $formattedReference): void
     {
         $paymentReference = PaymentReference::create(
             $type,
@@ -97,7 +97,7 @@ class PaymentReferenceTest extends TestCase
         $this->assertSame($formattedReference, $paymentReference->getFormattedReference());
     }
 
-    public function formattedReferenceProvider()
+    public function formattedReferenceProvider(): array
     {
         return [
             [PaymentReference::TYPE_QR, '012345678901234567890123456', '01 23456 78901 23456 78901 23456'],
@@ -110,7 +110,7 @@ class PaymentReferenceTest extends TestCase
         ];
     }
 
-    public function testQrCodeData()
+    public function testQrCodeData(): void
     {
         $paymentReference = PaymentReference::create(
             PaymentReference::TYPE_QR,

--- a/tests/DataGroup/Element/PaymentReferenceTest.php
+++ b/tests/DataGroup/Element/PaymentReferenceTest.php
@@ -10,7 +10,7 @@ class PaymentReferenceTest extends TestCase
     /**
      * @dataProvider qrReferenceProvider
      */
-    public function testQrReference($numberOfViolations, $value)
+    public function testQrReference(int $numberOfViolations, ?string $value)
     {
         $paymentReference = PaymentReference::create(
             PaymentReference::TYPE_QR,
@@ -20,7 +20,7 @@ class PaymentReferenceTest extends TestCase
         $this->assertSame($numberOfViolations, $paymentReference->getViolations()->count());
     }
 
-    public function qrReferenceProvider()
+    public function qrReferenceProvider(): array
     {
         return [
             [0, '012345678901234567890123456'],

--- a/tests/DataGroup/Element/StructuredAddressTest.php
+++ b/tests/DataGroup/Element/StructuredAddressTest.php
@@ -10,7 +10,7 @@ class StructuredAddressTest extends TestCase
     /**
      * @dataProvider nameProvider
      */
-    public function testName($numberOfValidations, $value)
+    public function testName($numberOfValidations, $value): void
     {
         $address = StructuredAddress::createWithoutStreet(
             $value,
@@ -22,7 +22,7 @@ class StructuredAddressTest extends TestCase
         $this->assertSame($numberOfValidations, $address->getViolations()->count());
     }
 
-    public function nameProvider()
+    public function nameProvider(): array
     {
         return [
             [0, 'A'],
@@ -38,7 +38,7 @@ class StructuredAddressTest extends TestCase
     /**
      * @dataProvider streetProvider
      */
-    public function testStreet($numberOfViolations, $value)
+    public function testStreet(int $numberOfViolations, string $value): void
     {
         $address = StructuredAddress::createWithStreet(
             'Thomas Mustermann',
@@ -52,7 +52,7 @@ class StructuredAddressTest extends TestCase
         $this->assertSame($numberOfViolations, $address->getViolations()->count());
     }
 
-    public function streetProvider()
+    public function streetProvider(): array
     {
         return [
             [0, ''],
@@ -67,7 +67,7 @@ class StructuredAddressTest extends TestCase
     /**
      * @dataProvider buildingNumberProvider
      */
-    public function testBuildingNumber($numberOfViolations, $value)
+    public function testBuildingNumber(int $numberOfViolations, ?string $value): void
     {
         $address = StructuredAddress::createWithStreet(
             'Thomas Mustermann',
@@ -81,7 +81,7 @@ class StructuredAddressTest extends TestCase
         $this->assertSame($numberOfViolations, $address->getViolations()->count());
     }
 
-    public function buildingNumberProvider()
+    public function buildingNumberProvider(): array
     {
         return [
             [0, null],
@@ -97,7 +97,7 @@ class StructuredAddressTest extends TestCase
     /**
      * @dataProvider postalCodeProvider
      */
-    public function testPostalCode($numberOfViolations, $value)
+    public function testPostalCode(int $numberOfViolations, string $value): void
     {
         $address = StructuredAddress::createWithStreet(
             'Thomas Mustermann',
@@ -111,7 +111,7 @@ class StructuredAddressTest extends TestCase
         $this->assertSame($numberOfViolations, $address->getViolations()->count());
     }
 
-    public function postalCodeProvider()
+    public function postalCodeProvider(): array
     {
         return [
             [0, '1'],
@@ -126,7 +126,7 @@ class StructuredAddressTest extends TestCase
     /**
      * @dataProvider cityProvider
      */
-    public function testCity($numberOfViolations, $value)
+    public function testCity(int $numberOfViolations, string $value)
     {
         $address = StructuredAddress::createWithStreet(
             'Thomas Mustermann',
@@ -140,7 +140,7 @@ class StructuredAddressTest extends TestCase
         $this->assertSame($numberOfViolations, $address->getViolations()->count());
     }
 
-    public function cityProvider()
+    public function cityProvider(): array
     {
         return [
             [0, 'A'],
@@ -154,7 +154,7 @@ class StructuredAddressTest extends TestCase
     /**
      * @dataProvider countryProvider
      */
-    public function testCountry($numberOfValidations, $value)
+    public function testCountry($numberOfValidations, $value): void
     {
         $address = StructuredAddress::createWithoutStreet(
             'Thomas Mustermann',
@@ -166,7 +166,7 @@ class StructuredAddressTest extends TestCase
         $this->assertSame($numberOfValidations, $address->getViolations()->count());
     }
 
-    public function countryProvider()
+    public function countryProvider(): array
     {
         return [
             [0, 'CH'],
@@ -208,12 +208,12 @@ class StructuredAddressTest extends TestCase
     /**
      * @dataProvider addressProvider
      */
-    public function testFullAddressString(StructuredAddress $address, $expected)
+    public function testFullAddressString(StructuredAddress $address, $expected): void
     {
         $this->assertSame($expected, $address->getFullAddress());
     }
 
-    public function addressProvider()
+    public function addressProvider(): array
     {
         return [
             [

--- a/tests/PaymentPart/Output/FpdfOutput/FpdfOutputTest.php
+++ b/tests/PaymentPart/Output/FpdfOutput/FpdfOutputTest.php
@@ -17,7 +17,7 @@ class FpdfOutputTest extends TestCase
     /**
      * @dataProvider validQrBillsProvider
      */
-    public function testValidQrBills(string $name, QrBill $qrBill)
+    public function testValidQrBills(string $name, QrBill $qrBill): void
     {
         $variations = [
             [
@@ -55,7 +55,7 @@ class FpdfOutputTest extends TestCase
         }
     }
 
-    public function testItThrowsSvgNotSupportedException()
+    public function testItThrowsSvgNotSupportedException(): void
     {
         $this->expectException(InvalidFpdfImageFormat::class);
 

--- a/tests/PaymentPart/Output/TcPdfOutput/TcPdfOutputTest.php
+++ b/tests/PaymentPart/Output/TcPdfOutput/TcPdfOutputTest.php
@@ -15,7 +15,7 @@ class TcPdfOutputTest extends TestCase
     /**
      * @dataProvider validQrBillsProvider
      */
-    public function testValidQrBills(string $name, QrBill $qrBill)
+    public function testValidQrBills(string $name, QrBill $qrBill): void
     {
         $variations = [
             [

--- a/tests/PaymentPart/TranslationTest.php
+++ b/tests/PaymentPart/TranslationTest.php
@@ -13,12 +13,12 @@ class TranslationTest extends TestCase
     /**
      * @dataProvider allTranslationsProvider
      */
-    public function testAllByLanguage($locale, $subset)
+    public function testAllByLanguage(string $locale, array $subset): void
     {
         $this->assertArraySubset($subset, Translation::getAllByLanguage($locale));
     }
 
-    public function allTranslationsProvider()
+    public function allTranslationsProvider(): array
     {
         return [
             ['de', ['paymentPart' => 'Zahlteil']],
@@ -31,12 +31,12 @@ class TranslationTest extends TestCase
     /**
      * @dataProvider singleTranslationProvider
      */
-    public function testGet($locale, $key, $translation)
+    public function testGet(string $locale, string $key, string $translation)
     {
         $this->assertSame($translation, Translation::get($key, $locale));
     }
 
-    public function singleTranslationProvider()
+    public function singleTranslationProvider(): array
     {
         return [
             ['de', 'paymentPart', 'Zahlteil'],

--- a/tests/QrBillTest.php
+++ b/tests/QrBillTest.php
@@ -52,18 +52,6 @@ class QrBillTest extends TestCase
         );
     }
 
-    public function testHeaderIsRequired()
-    {
-        $qrBill = $this->createQrBill([
-            'creditorInformationQrIban',
-            'creditor',
-            'paymentAmountInformation',
-            'paymentReferenceQr'
-        ]);
-
-        $this->assertSame(1, $qrBill->getViolations()->count());
-    }
-
     public function testHeaderMustBeValid()
     {
         $qrBill = $this->createQrBill([

--- a/tests/QrBillTest.php
+++ b/tests/QrBillTest.php
@@ -227,7 +227,7 @@ class QrBillTest extends TestCase
         ]);
 
         $qrBill->addAlternativeScheme(AlternativeScheme::create('foo'));
-        $qrBill->addAlternativeScheme((new AlternativeScheme()));
+        $qrBill->addAlternativeScheme(AlternativeScheme::create(''));
 
         $this->assertFalse($qrBill->isValid());
     }

--- a/tests/QrCode/QrCodeTest.php
+++ b/tests/QrCode/QrCodeTest.php
@@ -11,7 +11,7 @@ class QrCodeTest extends TestCase
     /**
      * @dataProvider supportedExtensionsProvider
      */
-    public function testSupportedFileExtensions($extension)
+    public function testSupportedFileExtensions(string $extension): void
     {
         $qrCode = new QrCode('This is a test code');
         $qrCode->setLogoHeight(10);
@@ -23,11 +23,12 @@ class QrCodeTest extends TestCase
             return;
         }
 
-        $this->assertNull($qrCode->writeFile($testfile));
+        $qrCode->writeFile($testfile);
+        $this->assertTrue(file_exists($testfile));
         unlink($testfile);
     }
 
-    public function supportedExtensionsProvider()
+    public function supportedExtensionsProvider(): array
     {
         return [
             ['svg'],
@@ -38,15 +39,15 @@ class QrCodeTest extends TestCase
     /**
      * @dataProvider unsupportedExtensionsProvider
      */
-    public function testUnsupportedFileExtensions($extension)
+    public function testUnsupportedFileExtensions(?string $extension): void
     {
         $this->expectException(UnsupportedFileExtensionException::class);
 
         $qrCode = new QrCode('This is a test code');
-        $this->assertNull($qrCode->writeFile(__DIR__ . '/../TestData/testfile.' . $extension));
+        $qrCode->writeFile(__DIR__ . '/../TestData/testfile.' . $extension);
     }
 
-    public function unsupportedExtensionsProvider()
+    public function unsupportedExtensionsProvider(): array
     {
         return [
             ['eps'],

--- a/tests/Reference/QrPaymentReferenceGeneratorTest.php
+++ b/tests/Reference/QrPaymentReferenceGeneratorTest.php
@@ -23,7 +23,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider qrPaymentReferenceProvider
      */
-    public function testMakesResultsViaConstructor($customerIdentification, $referenceNumber, $expectedResult)
+    public function testMakesResultsViaConstructor(?string $customerIdentification, string $referenceNumber, string $expectedResult): void
     {
         $qrReference = new QrPaymentReferenceGenerator(
             $customerIdentification,
@@ -36,7 +36,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider qrPaymentReferenceProvider
      */
-    public function testMakesResultsViaFacade($customerIdentification, $referenceNumber, $expectedResult)
+    public function testMakesResultsViaFacade(?string $customerIdentification, string $referenceNumber, string $expectedResult): void
     {
         $qrReference = QrPaymentReferenceGenerator::generate(
             $customerIdentification,
@@ -46,7 +46,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
         $this->assertSame($expectedResult, $qrReference);
     }
 
-    public function qrPaymentReferenceProvider()
+    public function qrPaymentReferenceProvider(): array
     {
         return [
             // Realistic real-life examples
@@ -68,7 +68,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider invalidQrPaymentReferenceProvider
      */
-    public function testInvalidQrPaymentReference($customerIdentification, $referenceNumber)
+    public function testInvalidQrPaymentReference(?string $customerIdentification, string $referenceNumber): void
     {
         $this->expectException(InvalidQrPaymentReferenceException::class);
 
@@ -78,7 +78,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
         );
     }
 
-    public function invalidQrPaymentReferenceProvider()
+    public function invalidQrPaymentReferenceProvider(): array
     {
         return [
             ['1234', '12345678901234567890123'], // too long in total
@@ -91,7 +91,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider invalidCustomerIdentificationNumberProvider
      */
-    public function testInvalidCustomerIdentificationNumber($value)
+    public function testInvalidCustomerIdentificationNumber(string $value): void
     {
         $this->expectException(InvalidQrPaymentReferenceException::class);
 
@@ -101,7 +101,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
         );
     }
 
-    public function invalidCustomerIdentificationNumberProvider()
+    public function invalidCustomerIdentificationNumberProvider(): array
     {
         return [
             ['123456789012'], // too long
@@ -113,7 +113,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider invalidReferenceNumberProvider
      */
-    public function testInvalidReferenceNumber($value)
+    public function testInvalidReferenceNumber(string $value): void
     {
         $this->expectException(InvalidQrPaymentReferenceException::class);
         
@@ -123,7 +123,7 @@ class QrPaymentReferenceGeneratorTest extends TestCase
         );
     }
 
-    public function invalidReferenceNumberProvider()
+    public function invalidReferenceNumberProvider(): array
     {
         return [
             ['1234567890123456789A'],  // non-digits

--- a/tests/Reference/RfCreditorReferenceGeneratorTest.php
+++ b/tests/Reference/RfCreditorReferenceGeneratorTest.php
@@ -11,7 +11,7 @@ class RfCreditorReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider rfCreditorReferenceProvider
      */
-    public function testMakesResultsViaConstructor($input)
+    public function testMakesResultsViaConstructor(string $input): void
     {
         $generator = new RfCreditorReferenceGenerator($input);
 
@@ -26,7 +26,7 @@ class RfCreditorReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider rfCreditorReferenceProvider
      */
-    public function testMakesResultsViaFacade($input)
+    public function testMakesResultsViaFacade(string $input): void
     {
         $output = RfCreditorReferenceGenerator::generate($input);
 
@@ -36,7 +36,7 @@ class RfCreditorReferenceGeneratorTest extends TestCase
         );
     }
 
-    public function rfCreditorReferenceProvider()
+    public function rfCreditorReferenceProvider(): array
     {
         return [
             ['1'],
@@ -49,14 +49,14 @@ class RfCreditorReferenceGeneratorTest extends TestCase
     /**
      * @dataProvider invalidReferenceProvider
      */
-    public function testInvalidReference($input)
+    public function testInvalidReference(string $input): void
     {
         $generator = new RfCreditorReferenceGenerator($input);
 
         $this->assertGreaterThan(0, $generator->getViolations()->count());
     }
 
-    public function invalidReferenceProvider()
+    public function invalidReferenceProvider(): array
     {
         return [
             ['aBcD eFgH iJkL mNoP qR12 34'], // to long

--- a/tests/String/StringModifierTest.php
+++ b/tests/String/StringModifierTest.php
@@ -10,7 +10,7 @@ class StringModifierTest extends TestCase
     /**
      * @dataProvider lineBreaksProvider
      */
-    public function testRemoveLineBreaks($string, $expectedResult)
+    public function testRemoveLineBreaks(?string $string, string $expectedResult): void
     {
         $this->assertSame(
             $expectedResult,
@@ -18,7 +18,7 @@ class StringModifierTest extends TestCase
         );
     }
 
-    public function lineBreaksProvider()
+    public function lineBreaksProvider(): array
     {
         return [
             [null, ''],
@@ -31,7 +31,7 @@ class StringModifierTest extends TestCase
     /**
      * @dataProvider multipleSpacesProvider
      */
-    public function testReplaceMultipleSpacesWithOne($string, $expectedResult)
+    public function testReplaceMultipleSpacesWithOne(?string $string, string $expectedResult): void
     {
         $this->assertSame(
             $expectedResult,
@@ -39,7 +39,7 @@ class StringModifierTest extends TestCase
         );
     }
 
-    public function multipleSpacesProvider()
+    public function multipleSpacesProvider(): array
     {
         return [
             [null, ''],
@@ -52,7 +52,7 @@ class StringModifierTest extends TestCase
     /**
      * @dataProvider stripWhitespaceProvider
      */
-    public function testStripWhitespace($string, $expectedResult)
+    public function testStripWhitespace(?string $string, string $expectedResult): void
     {
         $this->assertSame(
             $expectedResult,
@@ -60,7 +60,7 @@ class StringModifierTest extends TestCase
         );
     }
 
-    public function stripWhitespaceProvider()
+    public function stripWhitespaceProvider(): array
     {
         return [
             [null, ''],

--- a/tests/TestData/QrCodes/TestDataTest.php
+++ b/tests/TestData/QrCodes/TestDataTest.php
@@ -12,7 +12,7 @@ class TestDataTest extends TestCase
     /**
      * @dataProvider qrFileProvider
      */
-    public function testQrFile($file, $hash)
+    public function testQrFile(string $file, string $hash): void
     {
         $this->assertSame(
             $hash,
@@ -20,7 +20,7 @@ class TestDataTest extends TestCase
         );
     }
 
-    public function qrFileProvider()
+    public function qrFileProvider(): array
     {
         return [
             [__DIR__ . '/qr-additional-information.png', '3a23f70cc8cf519f66d27b73f002d828'],

--- a/tests/TestQrBillCreatorTrait.php
+++ b/tests/TestQrBillCreatorTrait.php
@@ -171,7 +171,7 @@ trait TestQrBillCreatorTrait
     public function invalidHeader(QrBill &$qrBill)
     {
         // INVALID EMPTY HEADER
-        $qrBill->setHeader(new Header());
+        $qrBill->setHeader(Header::create('', '', 5));
     }
 
     public function creditorInformationIban(QrBill &$qrBill)
@@ -297,7 +297,7 @@ trait TestQrBillCreatorTrait
 
     public function invalidAlternativeScheme(QrBill &$qrBill)
     {
-        $alternativeScheme = (new AlternativeScheme());
+        $alternativeScheme = (AlternativeScheme::create(''));
 
         $qrBill->addAlternativeScheme($alternativeScheme);
     }
@@ -332,6 +332,11 @@ trait TestQrBillCreatorTrait
 
     public function invalidAddress()
     {
-        return new CombinedAddress();
+        return CombinedAddress::create(
+            '',
+            '',
+            '',
+            ''
+        );
     }
 }

--- a/tests/TestQrBillCreatorTrait.php
+++ b/tests/TestQrBillCreatorTrait.php
@@ -149,7 +149,7 @@ trait TestQrBillCreatorTrait
 
     public function createQrBill(array $elements)
     {
-        $qrBill = new QrBill();
+        $qrBill = QrBill::create();
 
         foreach ($elements as $element) {
             $this->$element($qrBill);


### PR DESCRIPTION
**This is a pull request for development towards v3 of this library.**

* Drops support for PHP 7.2 and PHP 7.3
* Adds property type hints
* Adds type hints to tests
* Adds private constructors to all files
* Adds `EmptyAddress` and `EmptyAdditionalInformation` data elements