### PR TITLE
Update the 'Payment part' heading translations in French and Italian

### DIFF
--- a/src/PaymentPart/Translation/Translation.php
+++ b/src/PaymentPart/Translation/Translation.php
@@ -22,7 +22,7 @@ class Translation
         ],
 
         'fr' => [
-            'paymentPart' => 'Section de paiement',
+            'paymentPart' => 'Section paiement',
             'creditor' => 'Compte / Payable à',
             'reference' => 'Référence',
             'additionalInformation' => 'Informations supplémentaires',
@@ -38,7 +38,7 @@ class Translation
         ],
 
         'it' => [
-            'paymentPart' => 'Sezione di pagamento',
+            'paymentPart' => 'Sezione pagamento',
             'creditor' => 'Conto / Pagabile a',
             'reference' => 'Riferimento',
             'additionalInformation' => 'Informazioni supplementari',

--- a/tests/PaymentPart/TranslationTest.php
+++ b/tests/PaymentPart/TranslationTest.php
@@ -22,8 +22,8 @@ class TranslationTest extends TestCase
     {
         return [
             ['de', ['paymentPart' => 'Zahlteil']],
-            ['fr', ['paymentPart' => 'Section de paiement']],
-            ['it', ['paymentPart' => 'Sezione di pagamento']],
+            ['fr', ['paymentPart' => 'Section paiement']],
+            ['it', ['paymentPart' => 'Sezione pagamento']],
             ['en', ['paymentPart' => 'Payment part']]
         ];
     }
@@ -40,8 +40,8 @@ class TranslationTest extends TestCase
     {
         return [
             ['de', 'paymentPart', 'Zahlteil'],
-            ['fr', 'paymentPart', 'Section de paiement'],
-            ['it', 'paymentPart', 'Sezione di pagamento'],
+            ['fr', 'paymentPart', 'Section paiement'],
+            ['it', 'paymentPart', 'Sezione pagamento'],
             ['en', 'paymentPart', 'Payment part']
         ];
     }


### PR DESCRIPTION
According to the specifications document [docs/specs/ig-qr-bill-en-v2.1.pdf](https://github.com/sprain/php-swiss-qr-bill/blob/v3-wip/docs/specs/ig-qr-bill-en-v2.1.pdf) (as well as UBS who requested I make the change in my QR-Bills) the titles in French and Italian don't contain _de_ and _di_ respectively. 