### PR TITLE
Ignore phpstan error which is triggered due wrong docblock in tcpdf dependency

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,6 @@ parameters:
     level: 5
     paths:
         - src/
+    ignoreErrors:
+        - '#Parameter \#1 \$h of method TCPDF::setCellHeightRatio\(\) expects int, float given\.#'
+    reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
There is a wrong type annotation in tcpdf, which triggers phpstan.

We'll have to ignore this error until the [PR containing the fix](https://github.com/tecnickcom/TCPDF/pull/405) gets merged.