### PR TITLE
PHP8.1 compatibility update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
         stability: ['prefer-lowest', 'prefer-stable']
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Check coding standard
         run: vendor/bin/php-cs-fixer --no-interaction --dry-run --diff -v fix src/
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
 
       - name: Static analysis
         run: vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "dms/phpunit-arraysubset-asserts": "^0.1|^0.2",
         "fpdf/fpdf": "^1.82",
         "friendsofphp/php-cs-fixer": "^2.19",
-        "phpstan/phpstan": "^0.12.53",
+        "phpstan/phpstan": "^0.12.95",
         "symfony/css-selector": "^4.2",
         "symfony/var-dumper": "^5.1",
         "tecnickcom/tcpdf": "^6.3.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5422d8038a637493d9cbbfd1401e9d8",
+    "content-hash": "42872e90ee82584578bb6ae0d9c3a6ba",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -2709,16 +2709,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.86",
+            "version": "0.12.99",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "a84fdc53ecca7643dbc89ef8880d8b393a6c155a"
+                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a84fdc53ecca7643dbc89ef8880d8b393a6c155a",
-                "reference": "a84fdc53ecca7643dbc89ef8880d8b393a6c155a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
                 "shasum": ""
             },
             "require": {
@@ -2749,11 +2749,15 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.86"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
             },
             "funding": [
                 {
                     "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
                     "type": "github"
                 },
                 {
@@ -2765,7 +2769,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-08T11:29:01+00:00"
+            "time": "2021-09-12T20:09:55+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5374,5 +5378,5 @@
         "php": "^7.4|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
PHP8.1 is on it's tracks, so I made some preparation to make sure we're ready for it.

As of now, tests look good, so I think, in general there's seems to be no issues with php 8.1.

Due to several new features on language level like [enums](https://wiki.php.net/rfc/enumerations) or [Pure intersection types](https://wiki.php.net/rfc/pure-intersection-types), phpstan and php-cs-fixer require adjustments to be compatible with PHP8.1. Even when not using any of the new features, we still need to update those dependencies.
While phpstan already has a production release, which marks 8.1 compatibility, php-cs-fixer needs to ignore it's enviroment temporary for tests to succeed. Once the release for php-cs-fixer is out, we can revert this temporary fix and upgrade the version.

- [x] Update phpstan
- [ ] Update php-cs-fixer