### PR TITLE
use correct separator position

### DIFF
--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -216,8 +216,8 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
     {
         if (!$this->isPrintable()) {
             $this->tcPdf->SetLineStyle(['width' => 0.1, 'color' => [0, 0, 0]]);
-            $this->printLine(2, 193, 208, 193);
-            $this->printLine(62, 193, 62, 296);
+            $this->printLine(2, 192, 208, 192);
+            $this->printLine(62, 192, 62, 296);
             $this->tcPdf->SetFont(self::FONT, '', self::FONT_SIZE_FURTHER_INFORMATION);
             $this->setY(188);
             $this->setX(5);


### PR DESCRIPTION
297−105 = 192 mm
the payment part has a height of a DIN A6 width (105mm, half of DIN A4 210mm). The height of DIN A4 (297mm) minus the height of the payment part (105mm) is 192 mm.