### PR TITLE
Allow to get QR code image without creating a file

### DIFF
--- a/src/QrCode/QrCode.php
+++ b/src/QrCode/QrCode.php
@@ -66,6 +66,13 @@ final class QrCode
     {
         return $this->getQrCodeResult()->getDataUri();
     }
+    
+    /** @param "svg"|"png" $format */
+    public function getImageAsString(string $format = self::FILE_FORMAT_SVG): string
+    {
+        $this->setWriterByExtension($format);
+        return $this->getQrCodeResult()->getString();
+    }
 
     public function getText(): string
     {


### PR DESCRIPTION
Currently a QR code can only be retrieved via data-URI or by creating an image file, because the `->getString()` method of `ResultInterface` is not exposed/accessible in any way in the QrCode class. In my usages I do not need the QR code as a file, I want to directly include it in an email or to send it to the browser (as an image, not a data-URI), but in order to do that the library forces me to save it as a file in the filesystem, read that file and then delete the file, even though internally the image is available as a string already. Writing a file can be cumbersome or impossible in some contexts, for example in read-only docker containers, so not having to create a file would be quite helpful.

The only thing this pull request adds is a `getImageAsString` method on the class QrCode, where the format can be given as a parameter (and defaults to "svg", which is also the standard default of the class) and then returns the image as a string. This also resolves https://github.com/sprain/php-swiss-qr-bill/issues/155