### PR TITLE
Retain TCPDF's AutoPageBreak setting

### DIFF
--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -69,6 +69,7 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
     public function getPaymentPart(): void
     {
         $retainCellHeightRatio = $this->tcPdf->getCellHeightRatio();
+        $retainAutoPageBreak = $this->tcPdf->getAutoPageBreak();
 
         $this->tcPdf->SetAutoPageBreak(false);
 
@@ -85,6 +86,7 @@ final class TcPdfOutput extends AbstractOutput implements OutputInterface
         $this->addFurtherInformationContent();
 
         $this->tcPdf->setCellHeightRatio($retainCellHeightRatio);
+        $this->tcPdf->SetAutoPageBreak($retainAutoPageBreak);
     }
 
     private function addSwissQrCodeImage(): void


### PR DESCRIPTION
TCPDF's AutoPageBreak is disabled, but not retained. This bugfix retains the original setting like it is already done for the CellHeightRatio.