### PR TITLE
Added MemImage support for FpdfOutput

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
-      - name: Execute tests
+      - name: Execute tests in default environment
         run: vendor/bin/phpunit --verbose
+
+      - name: Execute tests in hardened environment
+        run: php  -d allow_url_fopen=0 -d memory_limit=64M -d register_globals=0 vendor/bin/phpunit --verbose
 
       - name: Check coding standard
         run: vendor/bin/php-cs-fixer --no-interaction --dry-run --diff -v fix src/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: vendor/bin/phpunit --verbose
 
       - name: Execute tests in hardened environment
-        run: php  -d allow_url_fopen=0 -d memory_limit=64M -d register_globals=0 vendor/bin/phpunit --verbose
+        run: php  -d allow_url_fopen=0 -d memory_limit=128M -d register_globals=0 vendor/bin/phpunit --verbose
 
       - name: Check coding standard
         run: vendor/bin/php-cs-fixer --no-interaction --dry-run --diff -v fix src/

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpunit/phpunit": "^9.0",
         "dg/bypass-finals": "^1.3",
         "dms/phpunit-arraysubset-asserts": "^0.2",
-        "fpdf/fpdf": "^1.82",
+        "fpdf/fpdf": "^1.85",
         "friendsofphp/php-cs-fixer": "^3.4",
         "khanamiryan/qrcode-detector-decoder": "^1.0.3",
         "phpstan/phpstan": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "474340e448cc2fbc1275f0161db94c0c",
+    "content-hash": "933db0df01aaba722003b47663495c44",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1355,22 +1355,29 @@
         },
         {
             "name": "fpdf/fpdf",
-            "version": "1.84.1",
+            "version": "1.85.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/coreydoughty/Fpdf.git",
-                "reference": "cfafa307947f7c646b87045d0decc67bdc423209"
+                "reference": "5ba6a7d4363174ac828a0c15cc1b4a8f845b1e16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/coreydoughty/Fpdf/zipball/cfafa307947f7c646b87045d0decc67bdc423209",
-                "reference": "cfafa307947f7c646b87045d0decc67bdc423209",
+                "url": "https://api.github.com/repos/coreydoughty/Fpdf/zipball/5ba6a7d4363174ac828a0c15cc1b4a8f845b1e16",
+                "reference": "5ba6a7d4363174ac828a0c15cc1b4a8f845b1e16",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.6.0"
             },
             "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "FPDF": "Fpdf\\Fpdf"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Fpdf\\": "src/Fpdf"
@@ -1395,9 +1402,9 @@
             ],
             "support": {
                 "issues": "https://github.com/coreydoughty/Fpdf/issues",
-                "source": "https://github.com/coreydoughty/Fpdf/tree/1.84.1"
+                "source": "https://github.com/coreydoughty/Fpdf/tree/1.85.0"
             },
-            "time": "2022-09-02T14:13:29+00:00"
+            "time": "2022-11-18T15:23:37+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",

--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -109,8 +109,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
                 46,
                 'png'
             );
-        }
-        elseif (method_exists($this->fpdf, 'MemImage')) {
+        } elseif (method_exists($this->fpdf, 'MemImage')) {
             $this->fpdf->MemImage(
                 $qrCode->getAsString($this->getQrCodeImageFormat()),
                 $xPosQrCode,

--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -100,7 +100,29 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         $yPosQrCode = 209.5 + $this->offsetY;
         $xPosQrCode = 67 + $this->offsetX;
 
-        $this->fpdf->Image($qrCode->getDataUri($this->getQrCodeImageFormat()), $xPosQrCode, $yPosQrCode, 46, 46, 'png');
+        if (ini_get('allow_url_fopen') === "1") {
+            $this->fpdf->Image(
+                $qrCode->getDataUri($this->getQrCodeImageFormat()),
+                $xPosQrCode,
+                $yPosQrCode,
+                46,
+                46,
+                'png'
+            );
+        }
+        elseif (method_exists($this->fpdf, 'MemImage')) {
+            $this->fpdf->MemImage(
+                $qrCode->getAsString($this->getQrCodeImageFormat()),
+                $xPosQrCode,
+                $yPosQrCode,
+                46,
+                46
+            );
+        } else {
+            throw new UnsupportedEnvironmentException(
+                'If directive "allow_url_fopen" is disabled, FPDFs "Memory Image Support" script is required'
+            );
+        }
     }
 
     private function addInformationContentReceipt(): void

--- a/src/PaymentPart/Output/FpdfOutput/UnsupportedEnvironmentException.php
+++ b/src/PaymentPart/Output/FpdfOutput/UnsupportedEnvironmentException.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Sprain\SwissQrBill\PaymentPart\Output\FpdfOutput;
+
+
+class UnsupportedEnvironmentException extends \RuntimeException
+{
+}

--- a/src/PaymentPart/Output/FpdfOutput/UnsupportedEnvironmentException.php
+++ b/src/PaymentPart/Output/FpdfOutput/UnsupportedEnvironmentException.php
@@ -3,7 +3,6 @@
 
 namespace Sprain\SwissQrBill\PaymentPart\Output\FpdfOutput;
 
-
 class UnsupportedEnvironmentException extends \RuntimeException
 {
 }

--- a/tests/PaymentPart/Output/FpdfOutput/FpdiOutputTest.php
+++ b/tests/PaymentPart/Output/FpdfOutput/FpdiOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace Sprain\Tests\SwissQrBill\PaymentPart\Output\FpdfOutput;
 
+use Fpdf\Traits\MemoryImageSupport\MemImageTrait;
 use PHPUnit\Framework\TestCase;
 use setasign\Fpdi\Fpdi;
 use Sprain\SwissQrBill\Exception\InvalidFpdfImageFormat;
@@ -35,7 +36,7 @@ final class FpdiOutputTest extends TestCase
         foreach ($variations as $variation) {
             $file = $variation['file'];
 
-            $fpdf = new Fpdi('P', 'mm', 'A4');
+            $fpdf = $this->instantiateFpdi();
             $fpdf->AddPage();
 
             $output = new FpdfOutput($qrBill, 'en', $fpdf);
@@ -67,7 +68,7 @@ final class FpdiOutputTest extends TestCase
             'paymentReferenceQr'
         ]);
 
-        $fpdf = new Fpdi('P', 'mm', 'A4');
+        $fpdf = $this->instantiateFpdi();
         $fpdf->AddPage();
 
         $output = new FpdfOutput($qrBill, 'en', $fpdf);
@@ -86,5 +87,21 @@ final class FpdiOutputTest extends TestCase
             return $matches[1];
         }
         return null;
+    }
+
+    private function instantiateFpdi($withMemImageSupport = null): Fpdi
+    {
+        if ($withMemImageSupport === null) {
+            $withMemImageSupport = !ini_get('allow_url_fopen');
+        }
+
+        if ($withMemImageSupport) {
+            return new class extends Fpdi {
+                // this uses the MemImageTrait from Fpdf/Fpdf
+                use MemImageTrait;
+            };
+        } else {
+            return new Fpdi('P', 'mm', 'A4');
+        }
     }
 }


### PR DESCRIPTION
This PR would add native support for Fpdf's [MemImage](http://www.fpdf.org/en/script/script45.php) script.

This would solve #192, but the tests depend on https://github.com/coreydoughty/Fpdf/pull/15 being accepted. Therefore this is marked as draft for now.