### PR TITLE
Re-introduce output of country code for Liechtenstein

### DIFF
--- a/src/DataGroup/Element/CombinedAddress.php
+++ b/src/DataGroup/Element/CombinedAddress.php
@@ -96,7 +96,7 @@ class CombinedAddress extends Address implements AddressInterface, SelfValidatab
             $lines[2] = $this->getAddressLine1();
         }
 
-        if (in_array($this->getCountry(), ['CH', 'LI'])) {
+        if ('CH' === $this->getCountry()) {
             $lines[3] = $this->getAddressLine2();
         } else {
             $lines[3] = sprintf("%s-%s", $this->getCountry(), $this->getAddressLine2());

--- a/src/DataGroup/Element/StructuredAddress.php
+++ b/src/DataGroup/Element/StructuredAddress.php
@@ -141,7 +141,7 @@ final class StructuredAddress extends Address implements AddressInterface, SelfV
             }
         }
 
-        if (in_array($this->getCountry(), ['CH', 'LI'])) {
+        if ('CH' === $this->getCountry()) {
             $lines[3] = sprintf("%s %s", $this->getPostalCode(), $this->getCity());
         } else {
             $lines[3] = sprintf("%s-%s %s", $this->getCountry(), $this->getPostalCode(), $this->getCity());

--- a/tests/DataGroup/Element/CombinedAddressTest.php
+++ b/tests/DataGroup/Element/CombinedAddressTest.php
@@ -179,7 +179,7 @@ final class CombinedAddressTest extends TestCase
                     '9490 Vaduz',
                     'LI'
                 ),
-                "Thomas Mustermann\nMusterweg 22a\n9490 Vaduz"
+                "Thomas Mustermann\nMusterweg 22a\nLI-9490 Vaduz"
             ],
             [
                 CombinedAddress::create(
@@ -256,7 +256,7 @@ final class CombinedAddressTest extends TestCase
                     '9490 Vaduz',
                     'LI'
                 ),
-                "Thomas Mustermann\nMusterweg 22a\n9490 Vaduz"
+                "Thomas Mustermann\nMusterweg 22a\nLI-9490 Vaduz"
             ],
             [
                 CombinedAddress::create(

--- a/tests/DataGroup/Element/StructuredAddressTest.php
+++ b/tests/DataGroup/Element/StructuredAddressTest.php
@@ -254,7 +254,7 @@ final class StructuredAddressTest extends TestCase
                     'Vaduz',
                     'LI'
                 ),
-                "Thomas Mustermann\n9490 Vaduz"
+                "Thomas Mustermann\nLI-9490 Vaduz"
             ],
             [
                 StructuredAddress::createWithoutStreet(
@@ -351,7 +351,7 @@ final class StructuredAddressTest extends TestCase
                     'Vaduz',
                     'LI'
                 ),
-                "Thomas Mustermann\n9490 Vaduz"
+                "Thomas Mustermann\nLI-9490 Vaduz"
             ],
             [
                 StructuredAddress::createWithoutStreet(


### PR DESCRIPTION
Fixes #199 

The specification says:
> «For invoicing to countries outside Switzerland, including Lichtenstein[sic!], the country code should be printed on the payment section.»

This PR re-introduces the country code in Liechtenstein on payment parts which was removed in #188 based on a misunderstood bugfix.