### PR TITLE
Make stylesheets of HtmlOutput stricter

### DIFF
--- a/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
+++ b/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
@@ -9,11 +9,11 @@ class PaymentPartTemplate
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -22,7 +22,7 @@ class PaymentPartTemplate
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -31,28 +31,28 @@ class PaymentPartTemplate
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -63,32 +63,32 @@ class PaymentPartTemplate
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
+++ b/src/PaymentPart/Output/HtmlOutput/Template/PaymentPartTemplate.php
@@ -36,29 +36,34 @@ class PaymentPartTemplate
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -66,29 +71,35 @@ class PaymentPartTemplate
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-additional-information.svg.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-additional-information.svg.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-additional-information.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-additional-information.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-additional-information.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-alternative-schemes.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-full-set.svg.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-full-set.svg.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-full-set.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-full-set.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-full-set.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-international-ultimate-debtor.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.svg.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.svg.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-minimal-setup.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-minimal-setup.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-with-mediumlong-creditor-and-unknown-debtor.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-and-long-addresses.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount-but-debtor.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-without-amount.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-information-zero-amount.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-non.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-payment-reference-scor.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.print.html
@@ -2,11 +2,11 @@
 #qr-bill {
 	box-sizing: border-box;
 	border-collapse: collapse;
-	color: #000;
+	color: #000 !important;
 }
 
 #qr-bill * {
-	font-family: Arial, Frutiger, Helvetica, "Liberation Sans";
+	font-family: Arial, Frutiger, Helvetica, "Liberation Sans"  !important;
 }
 
 #qr-bill img.qr-bill-placeholder {
@@ -15,7 +15,7 @@
 
 #qr-bill-separate-info {
     text-align: center;
-    font-size: 8pt;
+    font-size: 8pt !important;
     line-height: 9pt;
 	border-bottom: 0.75pt solid black;
 	height: 5mm;
@@ -24,28 +24,28 @@
 
 /* h1 / h2 */
 #qr-bill h1 {
-	font-size: 11pt;
-	font-weight: bold;
+	font-size: 11pt !important;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 	height: 7mm;
 }
 
 #qr-bill h2 {
-	font-weight: bold;
+	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-payment-part h2 {
-	font-size: 8pt;
-	line-height: 11pt;	
+	font-size: 8pt !important;
+	line-height: 11pt !important;	
     margin-top: 11pt;
 }
 
 #qr-bill-receipt h2 {
-	font-size: 6pt;
-	line-height: 8pt;	
+	font-size: 6pt !important;
+	line-height: 8pt !important;	
     margin-top: 8pt;
 }
 
@@ -56,32 +56,32 @@
 
 /* p */
 #qr-bill p {
-	font-weight: normal;
+	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
 }
 
 #qr-bill-receipt p {
-	font-size: 8pt;
-	line-height: 9pt;
+	font-size: 8pt !important;
+	line-height: 9pt !important;
 }
 
 #qr-bill-payment-part p {
-	font-size: 10pt;
-	line-height: 11pt;
+	font-size: 10pt !important;
+	line-height: 11pt !important;
 }
 
 #qr-bill-amount-area-receipt p{
-    line-height: 11pt;
+    line-height: 11pt !important;
 }
 
 #qr-bill-amount-area p{
-    line-height: 13pt;
+    line-height: 13pt !important;
 }
 
 #qr-bill-payment-further-information p {
-    font-size: 7pt;
-    line-height: 9pt;
+    font-size: 7pt !important;
+    line-height: 9pt !important;
 }
 
 /* Receipt */

--- a/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.print.html
+++ b/tests/TestData/HtmlOutput/qr-ultimate-debtor.svg.print.html
@@ -29,29 +29,34 @@
 	margin: 0;
 	padding: 0;
 	height: 7mm;
+	color: #000 !important;
 }
 
 #qr-bill h2 {
 	font-weight: bold !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2 {
 	font-size: 8pt !important;
 	line-height: 11pt !important;	
     margin-top: 11pt;
+	color: #000 !important;
 }
 
 #qr-bill-receipt h2 {
 	font-size: 6pt !important;
 	line-height: 8pt !important;	
     margin-top: 8pt;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part h2:first-child,
 #qr-bill-receipt h2:first-child {
 	margin-top: 0;
+	color: #000 !important;
 }
 
 /* p */
@@ -59,29 +64,35 @@
 	font-weight: normal !important;
 	margin: 0;
 	padding: 0;
+	color: #000 !important;
 }
 
 #qr-bill-receipt p {
 	font-size: 8pt !important;
 	line-height: 9pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-part p {
 	font-size: 10pt !important;
 	line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area-receipt p{
     line-height: 11pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-amount-area p{
     line-height: 13pt !important;
+	color: #000 !important;
 }
 
 #qr-bill-payment-further-information p {
     font-size: 7pt !important;
     line-height: 9pt !important;
+	color: #000 !important;
 }
 
 /* Receipt */


### PR DESCRIPTION
This pr adds additional `!important` and `color` statements to the styles of `HtmlOutput`. This makes sure the qr bill always looks according to specifications, regardless to other stylesheets that might be loaded in the document.