### PR TITLE
Remove deprecated UTF8_decode from FpdfOutput.php

### DIFF
--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -135,7 +135,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         // Title
         $this->fpdf->SetFont(self::FONT, 'B', self::FONT_SIZE_MAIN_TITLE);
         $this->SetXY(self::LEFT_PART_X, self::TITLE_Y);
-        $this->fpdf->MultiCell(0, 7, utf8_decode(Translation::get('receipt', $this->language)));
+        $this->fpdf->MultiCell(0, 7, iconv('UTF-8', 'windows-1252', Translation::get('receipt', $this->language)));
 
         // Elements
         $this->setY(204);
@@ -147,7 +147,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         // Acceptance section
         $this->fpdf->SetFont(self::FONT, 'B', self::FONT_SIZE_TITLE_RECEIPT);
         $this->SetXY(self::LEFT_PART_X, 274.3);
-        $this->fpdf->Cell(54, 0, utf8_decode(Translation::get('acceptancePoint', $this->language)), self::BORDER, '', self::ALIGN_RIGHT);
+        $this->fpdf->Cell(54, 0, iconv('UTF-8', 'windows-1252', Translation::get('acceptancePoint', $this->language)), self::BORDER, '', self::ALIGN_RIGHT);
     }
 
     private function addInformationContent(): void
@@ -155,7 +155,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         // Title
         $this->fpdf->SetFont(self::FONT, 'B', self::FONT_SIZE_MAIN_TITLE);
         $this->SetXY(self::RIGHT_PART_X, 195.2);
-        $this->fpdf->MultiCell(48, 7, utf8_decode(Translation::get('paymentPart', $this->language)));
+        $this->fpdf->MultiCell(48, 7, iconv('UTF-8', 'windows-1252', Translation::get('paymentPart', $this->language)));
 
         // Elements
         $this->setY(197.3);
@@ -228,7 +228,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
             $this->fpdf->Line(62 + $this->offsetX, 193 + $this->offsetY, 62 + $this->offsetX, 296 + $this->offsetY);
             $this->fpdf->SetFont(self::FONT, '', self::FONT_SIZE_FURTHER_INFORMATION);
             $this->setY(189.6);
-            $this->fpdf->MultiCell(0, 0, utf8_decode(Translation::get('separate', $this->language)), self::BORDER, self::ALIGN_CENTER);
+            $this->fpdf->MultiCell(0, 0, iconv('UTF-8', 'windows-1252', Translation::get('separate', $this->language)), self::BORDER, self::ALIGN_CENTER);
         }
     }
 
@@ -250,7 +250,9 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
     private function setTitleElement(Title $element, bool $isReceiptPart): void
     {
         $this->fpdf->SetFont(self::FONT, 'B', $isReceiptPart ? self::FONT_SIZE_TITLE_RECEIPT : self::FONT_SIZE_TITLE_PAYMENT_PART);
-        $this->fpdf->MultiCell(0, 2.8, utf8_decode(
+        $this->fpdf->MultiCell(0, 2.8, iconv(
+            'UTF-8',
+            'windows-1252',
             Translation::get(str_replace("text.", "", $element->getTitle()), $this->language)
         ));
         $this->fpdf->Ln($this->amountLS);
@@ -262,7 +264,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         $this->fpdf->MultiCell(
             $isReceiptPart ? 54 : 0,
             $isReceiptPart ? 3.3 : 4,
-            str_replace("text.", "", utf8_decode($element->getText())),
+            str_replace("text.", "", iconv('UTF-8', 'windows-1252', $element->getText())),
             self::BORDER,
             self::ALIGN_LEFT
         );


### PR DESCRIPTION
Hi

since [utf8_decode has been deprecated ](https://www.php.net/manual/en/function.utf8-decode.php) on PHP8.2 it spits out notices.

I use FPDF also on other places and had the same there. According to the [FPDF FAQ](http://www.fpdf.org/en/FAQ.php) no.3 they recommend to use iconv() to convert 'UTF8' to 'windows-1252' which is expected.

The tests no produce errors, since I didn't manage to renew the .png-files in the QrCodes Test data.
Alltough the PDF's looked correct and scanning the QR-Code with my ebanking-app worked.

Thanks a lot for your work!

philipp