### PR TITLE
Test ini-parameter for truthy instead of string

### DIFF
--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -100,7 +100,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         $yPosQrCode = 209.5 + $this->offsetY;
         $xPosQrCode = 67 + $this->offsetX;
 
-        if ("1" === ini_get('allow_url_fopen')) {
+        if ((bool)ini_get('allow_url_fopen')) {
             $this->fpdf->Image(
                 $qrCode->getDataUri($this->getQrCodeImageFormat()),
                 $xPosQrCode,

--- a/tests/PaymentPart/Output/FpdfOutput/FpdfOutputTest.php
+++ b/tests/PaymentPart/Output/FpdfOutput/FpdfOutputTest.php
@@ -80,7 +80,7 @@ final class FpdfOutputTest extends TestCase
 
     public function testItThrowsUnsupportedEnvironmentException(): void
     {
-        if (ini_get('allow_url_fopen') === "1") {
+        if ((bool)ini_get('allow_url_fopen')) {
             $this->markTestSkipped("This test only works in hardened environment.");
         }
 


### PR DESCRIPTION
Acording to the [docs](https://www.php.net/manual/en/function.ini-get.php), `ini_get` should return "", "0" or "1" for boolean config

> Note: When querying boolean values A boolean ini value of off will be returned as an empty string or "0" while a boolean ini value of on will be returned as "1". The function can also return the literal string of INI value.

However, according to #214 there seem to be environments, that do not follow this. So it's probably best to test for truthy.