### PR TITLE
Fix method return type

### DIFF
--- a/src/PaymentPart/Output/AbstractOutput.php
+++ b/src/PaymentPart/Output/AbstractOutput.php
@@ -34,7 +34,7 @@ abstract class AbstractOutput
         return $this->language;
     }
 
-    public function setPrintable(bool $printable): self
+    public function setPrintable(bool $printable): static
     {
         $this->printable = $printable;
 
@@ -46,7 +46,7 @@ abstract class AbstractOutput
         return $this->printable;
     }
 
-    public function setQrCodeImageFormat(string $fileExtension): self
+    public function setQrCodeImageFormat(string $fileExtension): static
     {
         $this->qrCodeImageFormat = $fileExtension;
 

--- a/src/PaymentPart/Output/AbstractOutput.php
+++ b/src/PaymentPart/Output/AbstractOutput.php
@@ -164,8 +164,6 @@ abstract class AbstractOutput
 
     protected function getQrCode(): QrCode
     {
-        $qrCode = $this->qrBill->getQrCode($this->getQrCodeImageFormat());
-
-        return $qrCode;
+        return $this->qrBill->getQrCode($this->getQrCodeImageFormat());
     }
 }

--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -82,7 +82,7 @@ final class FpdfOutput extends AbstractOutput implements OutputInterface
         $this->addFurtherInformationContent();
     }
 
-    public function setQrCodeImageFormat(string $fileExtension): AbstractOutput
+    public function setQrCodeImageFormat(string $fileExtension): static
     {
         if (QrCode::FILE_FORMAT_SVG === $fileExtension) {
             throw new InvalidFpdfImageFormat('SVG images are not allowed by FPDF.');


### PR DESCRIPTION
Fixes #224 

Replace return type `self` with `static` in abstract method.

See https://www.php.net/manual/en/language.oop5.late-static-bindings.php for more information on why.