### PR TITLE
Only keep supported characters within qr codes

### DIFF
--- a/src/DataGroup/Element/PaymentReference.php
+++ b/src/DataGroup/Element/PaymentReference.php
@@ -93,6 +93,7 @@ final class PaymentReference implements GroupSequenceProviderInterface, QrCodeab
         ]);
 
         $metadata->addPropertyConstraints('reference', [
+            /** @phpstan-ignore-next-line because docs do not match bc compatible syntax */
             new Assert\Type([
                 'type' => 'alnum',
                 'groups' => [self::TYPE_QR]

--- a/src/QrBill.php
+++ b/src/QrBill.php
@@ -34,6 +34,9 @@ final class QrBill implements SelfValidatableInterface
     private ?PaymentReference $paymentReference = null;
     private ?AdditionalInformation $additionalInformation = null;
 
+    /** @var array<string, string> */
+    private array $unsupportedCharacterReplacements = [];
+
     /** @var AlternativeScheme[] */
     private array $alternativeSchemes = [];
 
@@ -163,9 +166,17 @@ final class QrBill implements SelfValidatableInterface
     }
 
     /**
-     * @throws InvalidQrBillDataException
+     * @param array<string, string> $unsupportedCharacterReplacements
+     * @return $this
      */
-    public function getQrCode(?string $fileFormat = null, array $unsupportedCharacterReplacements = []): QrCode
+    public function setUnsupportedCharacterReplacements(array $unsupportedCharacterReplacements): self
+    {
+        $this->unsupportedCharacterReplacements = $unsupportedCharacterReplacements;
+
+        return $this;
+    }
+
+    public function getQrCode(?string $fileFormat = null): QrCode
     {
         if (!$this->isValid()) {
             throw new InvalidQrBillDataException(
@@ -176,7 +187,7 @@ final class QrBill implements SelfValidatableInterface
         return QrCode::create(
             $this->getQrCodeContent(),
             $fileFormat,
-            $unsupportedCharacterReplacements
+            $this->unsupportedCharacterReplacements
         );
     }
 

--- a/src/QrBill.php
+++ b/src/QrBill.php
@@ -165,7 +165,7 @@ final class QrBill implements SelfValidatableInterface
     /**
      * @throws InvalidQrBillDataException
      */
-    public function getQrCode(?string $fileFormat = null): QrCode
+    public function getQrCode(?string $fileFormat = null, array $unsupportedCharacterReplacements = []): QrCode
     {
         if (!$this->isValid()) {
             throw new InvalidQrBillDataException(
@@ -175,7 +175,8 @@ final class QrBill implements SelfValidatableInterface
 
         return QrCode::create(
             $this->getQrCodeContent(),
-            $fileFormat
+            $fileFormat,
+            $unsupportedCharacterReplacements
         );
     }
 

--- a/src/QrCode/QrCode.php
+++ b/src/QrCode/QrCode.php
@@ -45,6 +45,8 @@ final class QrCode
 
     private function __construct(string $data, string $fileFormat)
     {
+        $data = $this->cleanUnsupportedCharacters($data);
+
         if (class_exists(ErrorCorrectionLevel\ErrorCorrectionLevelMedium::class)) {
             // Endroid 4.x
             $this->qrCode = BaseQrCode::create($data)
@@ -125,6 +127,13 @@ final class QrCode
                 SvgWriter::WRITER_OPTION_COMPACT => false
             ]);
         }
+    }
+
+    private function cleanUnsupportedCharacters(string $data): string
+    {
+        $pattern = '/([^a-zA-Z0-9.,;:\'"+\-\/()?*\[\]{}|`´~ !^#%&<>÷=@_$£àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ\\n])/u';
+
+        return preg_replace($pattern, '', $data);
     }
 
     private function setWriterByExtension(string $extension): void

--- a/src/QrCode/QrCode.php
+++ b/src/QrCode/QrCode.php
@@ -36,6 +36,13 @@ final class QrCode
     /** @var array<string, bool> $writerOptions */
     private array $writerOptions = [SvgWriter::WRITER_OPTION_FORCE_XLINK_HREF => true];
 
+    /**
+     * @param string $data
+     * @param string|null $fileFormat
+     * @param array<string, string> $unsupportedCharacterReplacements
+     * @return self
+     * @throws UnsupportedFileExtensionException
+     */
     public static function create(string $data, string $fileFormat = null, array $unsupportedCharacterReplacements = []): self
     {
         if (null === $fileFormat) {
@@ -45,6 +52,12 @@ final class QrCode
         return new self($data, $fileFormat, $unsupportedCharacterReplacements);
     }
 
+    /**
+     * @param string $data
+     * @param string $fileFormat
+     * @param array<string, string> $unsupportedCharacterReplacements
+     * @throws UnsupportedFileExtensionException
+     */
     private function __construct(string $data, string $fileFormat, array $unsupportedCharacterReplacements)
     {
         $data = $this->replaceUnsupportedCharacters($data, $unsupportedCharacterReplacements);
@@ -132,6 +145,11 @@ final class QrCode
         }
     }
 
+    /**
+     * @param string $data
+     * @param array<string, string> $unsupportedCharacterReplacements
+     * @return string
+     */
     private function replaceUnsupportedCharacters(string $data, array $unsupportedCharacterReplacements): string
     {
         foreach ($unsupportedCharacterReplacements as $character => $replacement) {

--- a/tests/QrBillTest.php
+++ b/tests/QrBillTest.php
@@ -237,6 +237,43 @@ final class QrBillTest extends TestCase
         $this->assertFalse($qrBill->isValid());
     }
 
+    public function testItReplacesUnsupportedCharacters()
+    {
+        $qrBill = $this->createQrBill([
+            'header',
+            'creditorInformationQrIban',
+            'creditorWithUnsupportedCharacters',
+            'paymentAmountInformation',
+            'paymentReferenceQr',
+        ]);
+
+        $this->assertStringContainsString(
+            'Team We are the Champions!',
+            $qrBill->getQrCode()->getText()
+        );
+    }
+
+    public function testItConsidersReplacementCharacters()
+    {
+        $qrBill = $this->createQrBill([
+            'header',
+            'creditorInformationQrIban',
+            'creditorWithUnsupportedCharacters',
+            'paymentAmountInformation',
+            'paymentReferenceQr',
+        ]);
+
+        $unsupportedCharacterReplacements = [
+            '«' => '"',
+            '»' => '"',
+        ];
+
+        $this->assertStringContainsString(
+            'Team "We are the Champions!"',
+            $qrBill->getQrCode(null, $unsupportedCharacterReplacements)->getText()
+        );
+    }
+
     public function testCatchInvalidData()
     {
         $this->expectException(InvalidQrBillDataException::class);

--- a/tests/QrBillTest.php
+++ b/tests/QrBillTest.php
@@ -268,9 +268,11 @@ final class QrBillTest extends TestCase
             '»' => '"',
         ];
 
+        $qrBill->setUnsupportedCharacterReplacements($unsupportedCharacterReplacements);
+
         $this->assertStringContainsString(
             'Team "We are the Champions!"',
-            $qrBill->getQrCode(null, $unsupportedCharacterReplacements)->getText()
+            $qrBill->getQrCode()->getText()
         );
     }
 

--- a/tests/QrCode/QrCodeTest.php
+++ b/tests/QrCode/QrCodeTest.php
@@ -120,9 +120,43 @@ final class QrCodeTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidCharactersCodeProvider
+     * @dataProvider replacementCharactersProvider
      */
-    public function testItRemovesInvalidCharacters(string $providedString, string $expectedString): void
+    public function testItReplacesUnsupportedCharacters(string $providedString, array $replacements, string $expectedString): void
+    {
+        $qrCode = QrCode::create($providedString, null, $replacements);
+
+        $this->assertEquals(
+            $expectedString,
+            $qrCode->getText()
+        );
+    }
+
+    public function replacementCharactersProvider(): array
+    {
+        return [
+            'replaceSpecificUnsupportedCharacters' => [
+                'providedString' => '«This is a test!»',
+                'replacements' => [
+                    '«' => '"',
+                    '»' => '"'
+                ],
+                'expectedString' => '"This is a test!"'
+            ],
+            'ignoreReplacementsOfSupportedCharacters' => [
+                'providedString' => '«This is a test!»',
+                'replacements' => [
+                    't' => 'a',
+                ],
+                'expectedString' => 'This is a test!'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider unsupportedCharactersProvider
+     */
+    public function testItRemovesUnsupportedCharacters(string $providedString, string $expectedString): void
     {
         $qrCode = QrCode::create($providedString);
 
@@ -132,7 +166,7 @@ final class QrCodeTest extends TestCase
         );
     }
 
-    public function invalidCharactersCodeProvider(): array
+    public function unsupportedCharactersProvider(): array
     {
         return [
             'keepAllAllowedCharacters' => [

--- a/tests/QrCode/QrCodeTest.php
+++ b/tests/QrCode/QrCodeTest.php
@@ -118,4 +118,31 @@ final class QrCodeTest extends TestCase
             ]
         ];
     }
+
+    /**
+     * @dataProvider invalidCharactersCodeProvider
+     */
+    public function testItRemovesInvalidCharacters(string $providedString, string $expectedString): void
+    {
+        $qrCode = QrCode::create($providedString);
+
+        $this->assertEquals(
+            $expectedString,
+            $qrCode->getText()
+        );
+    }
+
+    public function invalidCharactersCodeProvider(): array
+    {
+        return [
+            'keepAllAllowedCharacters' => [
+                'providedString' => 'a-zA-Z0-9.,;:\'+-/()?*[]{}|`´~!"#%&<>÷=@_$£^àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ',
+                'expectedString' => 'a-zA-Z0-9.,;:\'+-/()?*[]{}|`´~!"#%&<>÷=@_$£^àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ'
+            ],
+            'removeUnallowedCharacters' => [
+                'providedString' => '«This is a test!»',
+                'expectedString' => 'This is a test!'
+            ],
+        ];
+    }
 }

--- a/tests/TestQrBillCreatorTrait.php
+++ b/tests/TestQrBillCreatorTrait.php
@@ -218,6 +218,11 @@ trait TestQrBillCreatorTrait
         $qrBill->setCreditor($this->structuredAddress());
     }
 
+    public function creditorWithUnsupportedCharacters(QrBill &$qrBill)
+    {
+        $qrBill->setCreditor($this->addressWithUnsupportedCharacters());
+    }
+
     public function creditorMediumLong(QrBill &$qrBill)
     {
         $qrBill->setCreditor($this->mediumLongAddress());
@@ -388,6 +393,16 @@ trait TestQrBillCreatorTrait
             'Heaps of Characters International Trading Company of Switzerland GmbH',
             'Street of the Mighty Long Names Where Heroes Live and Villans Die 75',
             '1000 Lausanne au bord du lac, où le soleil brille encore la nuit',
+            'CH'
+        );
+    }
+
+    public function addressWithUnsupportedCharacters()
+    {
+        return CombinedAddress::create(
+            'Team «We are the Champions!»',
+            'Rue examplaire 22a',
+            '1000 Lausanne',
             'CH'
         );
     }


### PR DESCRIPTION
Fixes #254

* Makes sure only supported characters are used within the qr code, removes others.
* Adds an option to provide custom replacements for unsupported characters. Example:
  ```php
  $qrBill->setUnsupportedCharacterReplacements([
    '«' => '"',
    '»' => '"'
  ]);
  ```