### PR TITLE
Modernize encoding conversion for FPDF

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "symfony/intl": "^4.4|^5.0|^6.0|^7.0",
         "kmukku/php-iso11649": "^1.5",
         "endroid/qr-code": "^4.4.4|^5.0",
-        "symfony/polyfill-intl-icu": "^1.23"
+        "symfony/polyfill-intl-icu": "^1.23",
+        "symfony/polyfill-mbstring": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": "~8.0.0|~8.1.0|~8.2.0|~8.3.0",
         "ext-dom": "*",
         "ext-bcmath": "*",
-        "ext-iconv": "*",
         "symfony/validator": "^4.4|^5.0|^6.0|^7.0",
         "symfony/intl": "^4.4|^5.0|^6.0|^7.0",
         "kmukku/php-iso11649": "^1.5",

--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -337,6 +337,6 @@ final class FpdfOutput extends AbstractOutput
     private function convertEncoding(string $text): string
     {
         // FPDF does not support unicode.
-        return mb_convert_encoding($text, 'Windows-1252', 'UTF-8');
+        return mb_convert_encoding($text, 'CP1252', 'UTF-8');
     }
 }

--- a/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
+++ b/src/PaymentPart/Output/FpdfOutput/FpdfOutput.php
@@ -137,7 +137,7 @@ final class FpdfOutput extends AbstractOutput
         // Title
         $this->fpdf->SetFont(self::FONT, 'B', self::FONT_SIZE_MAIN_TITLE);
         $this->SetXY(self::LEFT_PART_X, self::TITLE_Y);
-        $this->fpdf->MultiCell(0, 7, $this->toUtf8(Translation::get('receipt', $this->language)));
+        $this->fpdf->MultiCell(0, 7, $this->convertEncoding(Translation::get('receipt', $this->language)));
 
         // Elements
         $this->setY(204);
@@ -149,7 +149,7 @@ final class FpdfOutput extends AbstractOutput
         // Acceptance section
         $this->fpdf->SetFont(self::FONT, 'B', self::FONT_SIZE_TITLE_RECEIPT);
         $this->SetXY(self::LEFT_PART_X, 274.3);
-        $this->fpdf->Cell(54, 0, $this->toUtf8(Translation::get('acceptancePoint', $this->language)), self::BORDER, '', self::ALIGN_RIGHT);
+        $this->fpdf->Cell(54, 0, $this->convertEncoding(Translation::get('acceptancePoint', $this->language)), self::BORDER, '', self::ALIGN_RIGHT);
     }
 
     private function addInformationContent(): void
@@ -157,7 +157,7 @@ final class FpdfOutput extends AbstractOutput
         // Title
         $this->fpdf->SetFont(self::FONT, 'B', self::FONT_SIZE_MAIN_TITLE);
         $this->SetXY(self::RIGHT_PART_X, 195.2);
-        $this->fpdf->MultiCell(48, 7, $this->toUtf8(Translation::get('paymentPart', $this->language)));
+        $this->fpdf->MultiCell(48, 7, $this->convertEncoding(Translation::get('paymentPart', $this->language)));
 
         // Elements
         $this->setY(197.3);
@@ -229,7 +229,7 @@ final class FpdfOutput extends AbstractOutput
             $this->fpdf->Line(62 + $this->offsetX, 193 + $this->offsetY, 62 + $this->offsetX, 296 + $this->offsetY);
             $this->fpdf->SetFont(self::FONT, '', self::FONT_SIZE_FURTHER_INFORMATION);
             $this->setY(189.6);
-            $this->fpdf->MultiCell(0, 0, $this->toUtf8(Translation::get('separate', $this->language)), self::BORDER, self::ALIGN_CENTER);
+            $this->fpdf->MultiCell(0, 0, $this->convertEncoding(Translation::get('separate', $this->language)), self::BORDER, self::ALIGN_CENTER);
         }
     }
 
@@ -258,9 +258,7 @@ final class FpdfOutput extends AbstractOutput
         $this->fpdf->MultiCell(
             0,
             2.8,
-            iconv(
-                'UTF-8',
-                'windows-1252',
+            $this->convertEncoding(
                 Translation::get(str_replace('text.', '', $element->getTitle()), $this->language)
             )
         );
@@ -273,7 +271,7 @@ final class FpdfOutput extends AbstractOutput
         $this->fpdf->MultiCell(
             $isReceiptPart ? 54 : 0,
             $isReceiptPart ? 3.3 : 4,
-            str_replace('text.', '', $this->toUtf8($element->getText())),
+            str_replace('text.', '', $this->convertEncoding($element->getText())),
             self::BORDER,
             self::ALIGN_LEFT
         );
@@ -286,7 +284,7 @@ final class FpdfOutput extends AbstractOutput
         $this->fpdf->MultiCell(
             0,
             4,
-            $this->toUtf8($element->getText()),
+            $this->convertEncoding($element->getText()),
             self::BORDER,
             self::ALIGN_LEFT
         );
@@ -336,8 +334,9 @@ final class FpdfOutput extends AbstractOutput
         $this->fpdf->SetXY($x + $this->offsetX, $y + $this->offsetY);
     }
 
-    private function toUtf8(string $text): string
+    private function convertEncoding(string $text): string
     {
-        return iconv('UTF-8', 'windows-1252', $text) ?: '';
+        // FPDF does not support unicode.
+        return mb_convert_encoding($text, 'Windows-1252', 'UTF-8');
     }
 }

--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -283,7 +283,7 @@ final class TcPdfOutput extends AbstractOutput
     {
         $this->tcPdf->SetFont(self::FONT, '', self::FONT_SIZE_FURTHER_INFORMATION);
         $this->printMultiCell(
-            $this->toUtf8($element->getText()),
+            $element->getText(),
             0,
             0,
             self::BORDER
@@ -351,10 +351,5 @@ final class TcPdfOutput extends AbstractOutput
     private function printLine(int $x1, int $y1, int $x2, int $y2): void
     {
         $this->tcPdf->Line($x1+$this->offsetX, $y1+$this->offsetY, $x2+$this->offsetX, $y2+$this->offsetY);
-    }
-
-    private function toUtf8(string $text): string
-    {
-        return iconv('UTF-8', 'windows-1252', $text) ?: '';
     }
 }


### PR DESCRIPTION
Fixes #245 

I'm not entirly shure what the method `toUtf8` did, but surely not convert to UTF-8. It converted away from UTF-8; ~~my best guess it that it's to replace characters that are not allowed in the payment slip?~~

~~`ISO-8859-1` should be correct here, as the specs require _Latin Character Set_. But maybe there was a specific reason that the previous characterset was chosen?~~

Also, `iconv` is not able to handle MultiByteCharacters (🦓🦓🦓), so maybe we can fix that by using `mb_*` instead. I explicitly added the Symfony `mb_*`-polyfill, as its an indirect dependency anyway, so it will not bloat the package.

~~This PR should be considered as breaking change.~~