### PR TITLE
QrCode: Fixed 'Implicitly marking parameter  as nullable is deprecate…

### DIFF
--- a/src/QrCode/QrCode.php
+++ b/src/QrCode/QrCode.php
@@ -45,7 +45,7 @@ final class QrCode
      * @return self
      * @throws UnsupportedFileExtensionException
      */
-    public static function create(string $data, string $fileFormat = null, array $unsupportedCharacterReplacements = []): self
+    public static function create(string $data, ?string $fileFormat = null, array $unsupportedCharacterReplacements = []): self
     {
         if (null === $fileFormat) {
             $fileFormat = self::FILE_FORMAT_SVG;


### PR DESCRIPTION
Fixes the error we get with Phpunit and PHP8.4:

Sprain\SwissQrBill\QrCode\QrCode::create(): Implicitly marking parameter $fileFormat as nullable is deprecated, the explicit nullable type must be used instead