### PR TITLE
Modernize: PHP81 with rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "cs:fix": "vendor/bin/php-cs-fixer fix --verbose",
         "cs:diff": "vendor/bin/php-cs-fixer fix --dry-run --diff --verbose",
         "phpstan": "vendor/bin/phpstan analyse",
-        "phpunit": "vendor/bin/phpunit --verbose"
+        "phpunit": "vendor/bin/phpunit --verbose",
+        "rector": "vendor/bin/rector"
     },
     "conflict": {
         "khanamiryan/qrcode-detector-decoder": "1.0.6"

--- a/example/FpdfOutput/fpdf-example.php
+++ b/example/FpdfOutput/fpdf-example.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
 use Fpdf\Fpdf;
-use Sprain\SwissQrBill as QrBill;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
+use Sprain\SwissQrBill\PaymentPart\Output\FpdfOutput\FpdfOutput;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
@@ -26,7 +26,7 @@ $fpdf = new Fpdf('P', 'mm', 'A4');
 $fpdf->AddPage();
 
 // 3. Create a full payment part for FPDF
-$output = new QrBill\PaymentPart\Output\FpdfOutput\FpdfOutput($qrBill, 'en', $fpdf);
+$output = new FpdfOutput($qrBill, 'en', $fpdf);
 
 // 4. Optional, set layout options
 $displayOptions = new DisplayOptions();

--- a/example/HtmlOutput/html-example.php
+++ b/example/HtmlOutput/html-example.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
-use Sprain\SwissQrBill as QrBill;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
+use Sprain\SwissQrBill\PaymentPart\Output\HtmlOutput\HtmlOutput;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
@@ -9,7 +9,7 @@ require __DIR__ . '/../../vendor/autoload.php';
 require __DIR__ . '/../example.php';
 
 // 2. Create a full payment part in HTML
-$output = new QrBill\PaymentPart\Output\HtmlOutput\HtmlOutput($qrBill, 'en');
+$output = new HtmlOutput($qrBill, 'en');
 
 // 3. Optional, set layout options
 $displayOptions = new DisplayOptions();

--- a/example/TcPdfOutput/tcpdf-example.php
+++ b/example/TcPdfOutput/tcpdf-example.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
-use Sprain\SwissQrBill as QrBill;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
+use Sprain\SwissQrBill\PaymentPart\Output\TcPdfOutput\TcPdfOutput;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
@@ -16,7 +16,7 @@ $tcPdf->setPrintFooter(false);
 $tcPdf->AddPage();
 
 // 3. Create a full payment part for TcPDF
-$output = new QrBill\PaymentPart\Output\TcPdfOutput\TcPdfOutput($qrBill, 'en', $tcPdf);
+$output = new TcPdfOutput($qrBill, 'en', $tcPdf);
 
 // 4. Optional, set layout options
 $displayOptions = new DisplayOptions();

--- a/rector.php
+++ b/rector.php
@@ -3,20 +3,13 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\Set\ValueObject\SetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
+return RectorConfig::configure()
+    ->withPaths([
         __DIR__ . '/example',
         __DIR__ . '/src',
         __DIR__ . '/tests',
-    ]);
-
-    $rectorConfig->importNames(true);
-    $rectorConfig->importShortClasses(false)
-
-    $rectorConfig->sets([SetList::PHP_81]);
-
-    $rectorConfig->rule(ClassPropertyAssignToConstructorPromotionRector::class);
-};
+    ])->withImportNames(importShortClasses: false, removeUnusedImports: true)
+    ->withPhpSets() //checks composer.json for supported php versions
+    //->withAttributesSets(all: true)
+    ;

--- a/src/DataGroup/Element/Abstracts/Address.php
+++ b/src/DataGroup/Element/Abstracts/Address.php
@@ -2,7 +2,6 @@
 
 namespace Sprain\SwissQrBill\DataGroup\Element\Abstracts;
 
-use Sprain\SwissQrBill\String\StringAnalyzer;
 use Sprain\SwissQrBill\String\StringModifier;
 
 /**

--- a/src/DataGroup/Element/CombinedAddress.php
+++ b/src/DataGroup/Element/CombinedAddress.php
@@ -44,7 +44,7 @@ class CombinedAddress extends Address implements AddressInterface, SelfValidatab
         $this->name = self::normalizeString($name);
         $this->addressLine1 = self::normalizeString($addressLine1);
         $this->addressLine2 = self::normalizeString($addressLine2);
-        $this->country = strtoupper(self::normalizeString($country));
+        $this->country = strtoupper((string) self::normalizeString($country));
     }
 
     public static function create(

--- a/src/DataGroup/Element/PaymentReference.php
+++ b/src/DataGroup/Element/PaymentReference.php
@@ -53,8 +53,8 @@ final class PaymentReference implements GroupSequenceProviderInterface, QrCodeab
     public function getFormattedReference(): ?string
     {
         return match ($this->type) {
-            self::TYPE_QR => trim(strrev(chunk_split(strrev($this->reference), 5, ' '))),
-            self::TYPE_SCOR => trim(chunk_split($this->reference, 4, ' ')),
+            self::TYPE_QR => trim(strrev(chunk_split(strrev((string) $this->reference), 5, ' '))),
+            self::TYPE_SCOR => trim(chunk_split((string) $this->reference, 4, ' ')),
             default => null,
         };
     }

--- a/src/DataGroup/Element/StructuredAddress.php
+++ b/src/DataGroup/Element/StructuredAddress.php
@@ -54,7 +54,7 @@ final class StructuredAddress extends Address implements AddressInterface, SelfV
         $this->buildingNumber = self::normalizeString($buildingNumber);
         $this->postalCode = self::normalizeString($postalCode);
         $this->city = self::normalizeString($city);
-        $this->country = strtoupper(self::normalizeString($country));
+        $this->country = strtoupper((string) self::normalizeString($country));
     }
 
     public static function createWithoutStreet(

--- a/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
+++ b/src/PaymentPart/Output/TcPdfOutput/TcPdfOutput.php
@@ -59,9 +59,9 @@ final class TcPdfOutput extends AbstractOutput
     public function __construct(
         QrBill $qrBill,
         string $language,
-        private TCPDF|Fpdi $tcPdf,
-        private float $offsetX = 0,
-        private float $offsetY = 0
+        private readonly TCPDF|Fpdi $tcPdf,
+        private readonly float $offsetX = 0,
+        private readonly float $offsetY = 0
     ) {
         parent::__construct($qrBill, $language);
         $this->setQrCodeImageFormat(QrCode::FILE_FORMAT_SVG);

--- a/src/Reference/QrPaymentReferenceGenerator.php
+++ b/src/Reference/QrPaymentReferenceGenerator.php
@@ -53,7 +53,7 @@ final class QrPaymentReferenceGenerator implements SelfValidatableInterface
         $completeReferenceNumber  = $this->getCustomerIdentificationNumber();
 
         $strlen = $completeReferenceNumber ? strlen($completeReferenceNumber) : 0;
-        $completeReferenceNumber .= str_pad($this->getReferenceNumber(), 26 - $strlen, '0', STR_PAD_LEFT);
+        $completeReferenceNumber .= str_pad((string) $this->getReferenceNumber(), 26 - $strlen, '0', STR_PAD_LEFT);
         $completeReferenceNumber .= $this->modulo10($completeReferenceNumber);
 
         return $completeReferenceNumber;

--- a/tests/PaymentPart/Output/FpdfOutput/FpdfOutputTest.php
+++ b/tests/PaymentPart/Output/FpdfOutput/FpdfOutputTest.php
@@ -9,7 +9,6 @@ use Sprain\SwissQrBill\Exception\InvalidFpdfImageFormat;
 use Sprain\SwissQrBill\PaymentPart\Output\FpdfOutput\FpdfOutput;
 use Sprain\SwissQrBill\PaymentPart\Output\FpdfOutput\UnsupportedEnvironmentException;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
-use Sprain\SwissQrBill\PaymentPart\Output\VerticalSeparatorSymbolPosition;
 use Sprain\SwissQrBill\QrBill;
 use Sprain\SwissQrBill\QrCode\QrCode;
 use Sprain\Tests\SwissQrBill\TestQrBillCreatorTrait;

--- a/tests/PaymentPart/Output/FpdfOutput/FpdiOutputTest.php
+++ b/tests/PaymentPart/Output/FpdfOutput/FpdiOutputTest.php
@@ -8,7 +8,6 @@ use setasign\Fpdi\Fpdi;
 use Sprain\SwissQrBill\Exception\InvalidFpdfImageFormat;
 use Sprain\SwissQrBill\PaymentPart\Output\FpdfOutput\FpdfOutput;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
-use Sprain\SwissQrBill\PaymentPart\Output\VerticalSeparatorSymbolPosition;
 use Sprain\SwissQrBill\QrBill;
 use Sprain\SwissQrBill\QrCode\QrCode;
 use Sprain\Tests\SwissQrBill\TestQrBillCreatorTrait;

--- a/tests/PaymentPart/Output/HtmlOutput/HtmlOutputTest.php
+++ b/tests/PaymentPart/Output/HtmlOutput/HtmlOutputTest.php
@@ -5,7 +5,6 @@ namespace Sprain\Tests\SwissQrBill\PaymentPart\Output\HtmlOutput;
 use PHPUnit\Framework\TestCase;
 use Sprain\SwissQrBill\PaymentPart\Output\HtmlOutput\HtmlOutput;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
-use Sprain\SwissQrBill\PaymentPart\Output\VerticalSeparatorSymbolPosition;
 use Sprain\SwissQrBill\QrBill;
 use Sprain\SwissQrBill\QrCode\QrCode;
 use Sprain\Tests\SwissQrBill\TestCompactSvgQrCodeTrait;

--- a/tests/PaymentPart/Output/TcPdfOutput/FpdiOutputTest.php
+++ b/tests/PaymentPart/Output/TcPdfOutput/FpdiOutputTest.php
@@ -5,7 +5,6 @@ namespace Sprain\Tests\SwissQrBill\PaymentPart\Output\TcPdfOutput;
 use PHPUnit\Framework\TestCase;
 use setasign\Fpdi\Tcpdf\Fpdi;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
-use Sprain\SwissQrBill\PaymentPart\Output\VerticalSeparatorSymbolPosition;
 use Sprain\SwissQrBill\PaymentPart\Output\TcPdfOutput\TcPdfOutput;
 use Sprain\SwissQrBill\QrBill;
 use Sprain\SwissQrBill\QrCode\QrCode;

--- a/tests/PaymentPart/Output/TcPdfOutput/TcPdfOutputTest.php
+++ b/tests/PaymentPart/Output/TcPdfOutput/TcPdfOutputTest.php
@@ -4,7 +4,6 @@ namespace Sprain\Tests\SwissQrBill\PaymentPart\Output\TcPdfOutput;
 
 use PHPUnit\Framework\TestCase;
 use Sprain\SwissQrBill\PaymentPart\Output\DisplayOptions;
-use Sprain\SwissQrBill\PaymentPart\Output\VerticalSeparatorSymbolPosition;
 use Sprain\SwissQrBill\PaymentPart\Output\TcPdfOutput\TcPdfOutput;
 use Sprain\SwissQrBill\QrBill;
 use Sprain\SwissQrBill\QrCode\QrCode;


### PR DESCRIPTION
Inspired by #269, I took a dive whether there's some more code to modernize. I realized, that you already added Rector in #265, but it seems like either the 8.1 preset was updated since then, or it was not fully applied?

This PR
- simplifies and improves the rector config
  - `importNames` and `importShortClasses` config was kept
  - `removeUnusedImports` was added
  - `withPhpSets` uses the Composer config by default, so no explicit declaring of the set is required
- makes Output-examples more consistent and fixes, that Rector wants to remove the duplicate `Sprain\SwissQrBill as QrBill` import
- applies Rector for PHP81 set:
  - explicit `(string)` casts to address the [deprecation of passing null to non-nullable parameters](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal)
  - apply newly introduced `noUnusedImports` fixer