### PR TITLE
[Specs 2.3] Make sure the QrReference does not contain only zeros

### DIFF
--- a/src/Reference/QrPaymentReferenceGenerator.php
+++ b/src/Reference/QrPaymentReferenceGenerator.php
@@ -61,10 +61,10 @@ final class QrPaymentReferenceGenerator implements SelfValidatableInterface
             );
         }
 
-        $completeReferenceNumber  = $this->getCustomerIdentificationNumber();
+        $completeReferenceNumber  = $this->customerIdentificationNumber;
 
         $strlen = $completeReferenceNumber ? strlen($completeReferenceNumber) : 0;
-        $completeReferenceNumber .= str_pad($this->getReferenceNumber(), 26 - $strlen, '0', STR_PAD_LEFT);
+        $completeReferenceNumber .= str_pad($this->referenceNumber, 26 - $strlen, '0', STR_PAD_LEFT);
         $completeReferenceNumber .= $this->modulo10($completeReferenceNumber);
 
         return $completeReferenceNumber;
@@ -84,23 +84,34 @@ final class QrPaymentReferenceGenerator implements SelfValidatableInterface
         ]);
 
         $metadata->addPropertyConstraints('referenceNumber', [
-            // Only numbers are allowed (including leading zeros)
             new Assert\Regex([
                 'pattern' => '/^\d*$/',
-                'match' => true
+                'match' => true,
+                'message' => 'The reference number must not contain any non-numeric characters.'
             ]),
             new Assert\NotBlank()
         ]);
 
-        $metadata->addConstraint(new Assert\Callback('validateFullReference'));
+        $metadata->addConstraint(new Assert\Callback('validateFullReferenceLength'));
+        $metadata->addConstraint(new Assert\Callback('validateNotExclusivelyZeros'));
     }
 
-    public function validateFullReference(ExecutionContextInterface $context): void
+    public function validateFullReferenceLength(ExecutionContextInterface $context): void
     {
         $strlenCustomerIdentificationNumber = $this->customerIdentificationNumber ? strlen($this->customerIdentificationNumber) : 0;
 
         if ($strlenCustomerIdentificationNumber + strlen($this->referenceNumber) > 26) {
-            $context->buildViolation('The length of customer identification number + reference number may not exceed 26 characters in total.')
+            $context->buildViolation('The length of customer identification number + reference number must not exceed 26 characters in total.')
+                ->addViolation();
+        }
+    }
+
+    public function validateNotExclusivelyZeros(ExecutionContextInterface $context): void
+    {
+        $regex = '/^0*$/';
+
+        if (preg_match($regex, ($this->customerIdentificationNumber ?? '0')) && preg_match($regex, $this->referenceNumber)) {
+            $context->buildViolation('The qr reference must not consist exclusively of zeros.')
                 ->addViolation();
         }
     }

--- a/tests/Reference/QrPaymentReferenceGeneratorTest.php
+++ b/tests/Reference/QrPaymentReferenceGeneratorTest.php
@@ -34,16 +34,19 @@ final class QrPaymentReferenceGeneratorTest extends TestCase
     public static function qrPaymentReferenceProvider(): array
     {
         return [
-            // Realistic real-life examples
-            ['310014', '18310019779911119', '310014000183100197799111196'], // https://www.tkb.ch/download/online/BESR-Handbuch.pdf
-            ['040329', '340 ', '040329000000000000000003406'], // https://www.lukb.ch/documents/10620/13334/LUKB-BESR-Handbuch.pdf
-            ['247656', '3073000002311006 ', '247656000030730000023110061'], // https://hilfe.flexbuero.ch/article/1181/
+            // Real-life examples
+            ['310014', '18310019779911119', '310014000183100197799111196'],
+            ['040329', '340 ', '040329000000000000000003406'],
+            ['247656', '3073000002311006 ', '247656000030730000023110061'],
+
+            // More allowed combinations
             ['123456', '11223344', '123456000000000000112233440'],
             ['1234567890', '11223344', '123456789000000000112233444'],
             ['1234', '11223344', '123400000000000000112233449'],
             ['000000', '11223344', '000000000000000000112233442'],
             ['', '11223344', '000000000000000000112233442'],
             [null, '11223344', '000000000000000000112233442'],
+            ['1234', '000000', '123400000000000000000000001'],
 
             // Correct handling of whitespace
             [' 310 014 ', ' 1831001 9779911119 ', '310014000183100197799111196'],
@@ -68,6 +71,9 @@ final class QrPaymentReferenceGeneratorTest extends TestCase
             ['123456', '123456789012345678901'], // too long in total
             ['12345678901', '1234567890123456'], // too long in total
             [null, '123456789012345678901234567'], // too long in total
+            [null, '00000000'], // only zeros
+            [null, '0'],        // only zeros
+            ['00', '00'],       // only zeros
         ];
     }
 


### PR DESCRIPTION
Closes #275

Makes sure, the `QrPaymentReference` does not consist exclusively of zeros.