### PR TITLE
Add .gitattributes to exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github export-ignore
+/docs export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.php-cs-fixer.dist.php export-ignore
+phpstan.neon.dist export-ignore
+phpunit.xml.dist export-ignore
+rector.php export-ignore


### PR DESCRIPTION
This reduces the amount of files downloaded/used when installing the package through composer without losing any functionality. The size is reduced from about 25.5MB to 0.25MB, saving lots of bandwidth and space. My whole vendor directory for a reasonably sized project is at 208MB, so getting rid of 25MB in just one package would be a good improvement.

The excluded files can be retrieved via the Github repository, in reality I do not think anybody will even notice they are gone. I also think it makes the package easier to use, as when you look at the installed package you only see the most relevant aspects (which are mainly src, examples, README).