### PR TITLE
Fix thousands separator in qr code data

### DIFF
--- a/src/DataGroup/Element/PaymentAmountInformation.php
+++ b/src/DataGroup/Element/PaymentAmountInformation.php
@@ -60,14 +60,8 @@ final class PaymentAmountInformation implements QrCodeableInterface, SelfValidat
 
     public function getQrCodeData(): array
     {
-        if (null !== $this->getAmount()) {
-            $amountOutput = $this->getFormattedAmount();
-        } else {
-            $amountOutput = null;
-        }
-
         return [
-            $amountOutput,
+            $this->getFormattedAmountForQrCode(),
             $this->getCurrency()
         ];
     }
@@ -87,5 +81,15 @@ final class PaymentAmountInformation implements QrCodeableInterface, SelfValidat
                 self::CURRENCY_EUR
             ])
         ]);
+    }
+
+    private function getFormattedAmountForQrCode(): ?string
+    {
+        if (null === $this->amount) {
+            return null;
+        }
+
+        // Unlike the formatted code for the payment part, the amount in the qr code has no thousands separator
+        return number_format($this->amount, 2, '.', '');
     }
 }

--- a/tests/DataGroup/Element/PaymentAmountInformationTest.php
+++ b/tests/DataGroup/Element/PaymentAmountInformationTest.php
@@ -81,18 +81,24 @@ final class PaymentAmountInformationTest extends TestCase
         ];
     }
 
-    public function testQrCodeData(): void
+    #[DataProvider('qrCodeDataProvider')]
+    public function testQrCodeData(string $currency, ?float $amount, array $expected): void
     {
         $paymentAmountInformation = PaymentAmountInformation::create(
-            'CHF',
-            25
+            $currency,
+            $amount
         );
 
-        $expected = [
-            '25.00',
-            'CHF'
-        ];
-
         $this->assertSame($expected, $paymentAmountInformation->getQrCodeData());
+    }
+
+    public static function qrCodeDataProvider(): array
+    {
+        return [
+            ['CHF', 25, ['25.00', 'CHF']],
+            ['CHF', 2500, ['2500.00', 'CHF']],
+            ['CHF', null, [null, 'CHF']],
+            ['EUR', 0.2, ['0.20', 'EUR']],
+        ];
     }
 }


### PR DESCRIPTION
Fixes issue with invalid space as thousands separator in amount in qr code data, reported in https://github.com/sprain/php-swiss-qr-bill/commit/0754bda7e60a5cdc05127b349516e0aeea39bc77#commitcomment-172049663